### PR TITLE
Potential fix for code scanning alert no. 942: Clear-text logging of sensitive information

### DIFF
--- a/Rest/scripts/scripts/setup-supabase-admin.js
+++ b/Rest/scripts/scripts/setup-supabase-admin.js
@@ -138,7 +138,9 @@ async function setupAdminAccount() {
     console.log('You can now login at:');
     console.log('   URL: http://localhost:3001/admin/login');
     console.log(`   Email: ${adminEmail}`);
-    console.log(`   Password: ${adminPassword}\n`);
+    // Password will not be logged for security reasons.
+    console.log("   Password: [REDACTED - not logged for security]");
+    // If you need the password, please refer to the value you provided during setup, or set/reset it securely.
   } catch (error) {
     console.error('❌ Error setting up admin account:', error.message);
   }


### PR DESCRIPTION
Potential fix for [https://github.com/FoushWare/elzatona_web/security/code-scanning/942](https://github.com/FoushWare/elzatona_web/security/code-scanning/942)

To fix the problem, we should ensure that the admin password is not printed to the console. Instead of logging the password in clear text, the script can notify the user that the password has been set (and, optionally, instruct them to save it securely, or prompt it only through secure means if essential). If the password must be communicated, consider displaying it only after explicit user confirmation, but in most cases it is preferable to never log a password at all.

**Detailed practical fix:**  
- In `Rest/scripts/scripts/setup-supabase-admin.js`, find the section that logs the password (line 141).
- Remove the line that logs the password.
- Optionally, add a message to remind the user to save the password securely if it was displayed earlier or set interactively.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
