### PR TITLE
Potential fix for code scanning alert no. 941: Clear-text logging of sensitive information

### DIFF
--- a/Rest/scripts/scripts/setup-supabase-admin.js
+++ b/Rest/scripts/scripts/setup-supabase-admin.js
@@ -31,7 +31,7 @@ async function setupAdminAccount() {
     }
 
     console.log(`   Email: ${adminEmail}`);
-    console.log(`   Password: ${adminPassword}`);
+    console.log(`   Password: [REDACTED]`);
     console.log(`   Name: ${adminName}`);
     console.log(`   Role: ${adminRole}\n`);
 


### PR DESCRIPTION
Potential fix for [https://github.com/FoushWare/elzatona_web/security/code-scanning/941](https://github.com/FoushWare/elzatona_web/security/code-scanning/941)

To fix the problem, remove or redact the logging of sensitive data (`adminPassword`) on line 34. In general, logging of secrets (passwords, tokens, API keys, etc.) should be avoided. If logging is needed for debugging, display only the existence (e.g., length or masked value), or omit the value entirely. 

The best solution here is to entirely remove or redact the password printout on line 34. You may optionally inform the user that a password was provided (or not), without showing the actual value. For example, you can log its length, or replace the password with a generic masked string like `[REDACTED]` or `********`. 

**Steps to implement:**
- Remove or replace line 34 in `Rest/scripts/scripts/setup-supabase-admin.js` to avoid logging the `adminPassword` in clear text.
- Optionally, add a statement that prints `'Password: [REDACTED]'` or similar, or the length of the password if still desired for debugging (but not the value).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
