### PR TITLE
Potential fix for code scanning alert no. 940: Clear-text logging of sensitive information

### DIFF
--- a/Rest/scripts/scripts/setup-admin-complete.js
+++ b/Rest/scripts/scripts/setup-admin-complete.js
@@ -127,7 +127,7 @@ async function setupCompleteAdmin() {
         console.log('You can now login at:');
         console.log('   URL: http://localhost:3001/admin/login');
         console.log(`   Email: ${adminEmail}`);
-        console.log(`   Password: ${adminPassword}\n`);
+        console.log(`   Password: [REDACTED]\n`);
         return;
       } else {
         // Create admin record for existing user
@@ -185,7 +185,7 @@ async function setupCompleteAdmin() {
     console.log('You can now login at:');
     console.log('   URL: http://localhost:3001/admin/login');
     console.log(`   Email: ${adminEmail}`);
-    console.log(`   Password: ${adminPassword}\n`);
+    console.log(`   Password: [REDACTED]\n`);
   } catch (error) {
     console.error('❌ Error setting up admin:', error.message);
   }


### PR DESCRIPTION
Potential fix for [https://github.com/FoushWare/elzatona_web/security/code-scanning/940](https://github.com/FoushWare/elzatona_web/security/code-scanning/940)

To fix the issue, we should remove or hide the logging of the adminPassword variable in console output. The lines that disclose the password (lines 130 and 188) should be updated to prevent writing the password value to the console. Instead, we can display a generic message that tells the user where to obtain the password (such as from the environment variable), or simply omit it and let the administrator consult their input source.

Specifically, change:
- Lines 130 and 188: Replace the output that displays the password value with a more appropriate message such as "Password: [REDACTED]" or "Password: See environment variable/SUPABASE admin password source".

No additional imports or dependencies are needed; just edit the relevant lines to prevent logging the raw password.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
