### PR TITLE
Potential fix for code scanning alert no. 939: Clear-text logging of sensitive information

### DIFF
--- a/Rest/scripts/scripts/setup-admin-final.js
+++ b/Rest/scripts/scripts/setup-admin-final.js
@@ -154,7 +154,7 @@ CREATE POLICY "Service role can manage admins" ON admins FOR ALL USING (
     console.log('You can now login at:');
     console.log('   URL: http://localhost:3001/admin/login');
     console.log(`   Email: ${adminEmail}`);
-    console.log(`   Password: ${adminPassword}\n`);
+    console.log('   Password: [hidden - use the value set in INITIAL_ADMIN_PASSWORD]\n');
   } catch (error) {
     console.error('❌ Error setting up admin:', error.message);
   }


### PR DESCRIPTION
Potential fix for [https://github.com/FoushWare/elzatona_web/security/code-scanning/939](https://github.com/FoushWare/elzatona_web/security/code-scanning/939)

To resolve the issue, we should remove or redact the logging of the password so it is not output in plaintext to the console. Specifically, in file `Rest/scripts/scripts/setup-admin-final.js` on or around line 157, the line:

```js
console.log(`   Password: ${adminPassword}\n`);
```

should be modified to remove or obscure the password value. A common practice is to print a message stating that the password was set (or where to retrieve it), or to advise the user to reference their environment variables. Retaining the log message about the email is ok, since emails are not as sensitive (though still PII—if that's an issue, those might be redacted as well).

No new imports or dependencies are needed for this change; it is a straightforward string change. No other regions of the file need to be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
