### PR TITLE
Potential fix for code scanning alert no. 938: Clear-text logging of sensitive information

### DIFF
--- a/Rest/scripts/scripts/setup-admin-complete.js
+++ b/Rest/scripts/scripts/setup-admin-complete.js
@@ -127,7 +127,7 @@ async function setupCompleteAdmin() {
         console.log('You can now login at:');
         console.log('   URL: http://localhost:3001/admin/login');
         console.log(`   Email: ${adminEmail}`);
-        console.log(`   Password: ${adminPassword}\n`);
+        console.log('   Password: [hidden for security]\n');
         return;
       } else {
         // Create admin record for existing user
@@ -185,7 +185,7 @@ async function setupCompleteAdmin() {
     console.log('You can now login at:');
     console.log('   URL: http://localhost:3001/admin/login');
     console.log(`   Email: ${adminEmail}`);
-    console.log(`   Password: ${adminPassword}\n`);
+    console.log('   Password: [hidden for security]\n');
   } catch (error) {
     console.error('❌ Error setting up admin:', error.message);
   }


### PR DESCRIPTION
Potential fix for [https://github.com/FoushWare/elzatona_web/security/code-scanning/938](https://github.com/FoushWare/elzatona_web/security/code-scanning/938)

To fix the issue, all lines that print the admin password directly to the console should be modified to avoid revealing the actual password. Instead, the code should instruct the user that the password has been set, without printing its clear value. Specifically, update line 130 (and the equivalent block after admin creation in line 188) to replace the output ``console.log(`   Password: ${adminPassword}\n`)`` with a generic message such as ``console.log('   Password: [hidden for security]')`` or direct the user to refer to their input or configured source. Ensure all locations where the password is printed are updated.

No new methods or imports are required; just update the offending `console.log` calls.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
