### PR TITLE
Potential fix for code scanning alert no. 791: Incomplete multi-character sanitization

### DIFF
--- a/apps/website/src/app/free-style-practice/page.tsx
+++ b/apps/website/src/app/free-style-practice/page.tsx
@@ -729,7 +729,12 @@ const QuestionContent = ({ content }: { content: string }) => {
       if (textContent.trim()) {
         let cleanText = decodeHtmlEntities(textContent);
         cleanText = cleanText.replace(/<code[^>]*>([^<]{1,30})<\/code>/gi, '`$1`');
-        cleanText = cleanText.replace(/<[^>]+>/g, '');
+        // Repeated tag removal to prevent incomplete sanitization
+        let prev;
+        do {
+          prev = cleanText;
+          cleanText = cleanText.replace(/<[^>]+>/g, '');
+        } while (cleanText !== prev);
         for (let i = 0; i < 3; i++) {
           cleanText = cleanText
             .replace(/<pr<cod?/gi, '')


### PR DESCRIPTION
Potential fix for [https://github.com/FoushWare/elzatona_web/security/code-scanning/791](https://github.com/FoushWare/elzatona_web/security/code-scanning/791)

The best fix is to replace the single-pass HTML tag removal on line 732 with a safer approach. The preferred way is to use a well-tested HTML sanitization library (e.g. `sanitize-html` for Node/React). If that is not feasible and we must stick with regexes, then the code should apply the regex repeatedly until all HTML tags are removed. This is done by looping the replacement until the string no longer changes. Only edit the region shown, maintaining the intended removal but making it robust against multi-character tag reformation.  
- Edit the block around line 732 where `.replace(/<[^>]+>/g, '')` is called.
- If importing a library is allowed inside the shown code, prefer using `sanitize-html`. Otherwise, implement a safer, repeated replacement.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
