### PR TITLE
Potential fix for code scanning alert no. 793: Incomplete multi-character sanitization

### DIFF
--- a/apps/website/src/app/free-style-practice/page.tsx
+++ b/apps/website/src/app/free-style-practice/page.tsx
@@ -789,8 +789,12 @@ const QuestionContent = ({ content }: { content: string }) => {
       let cleanText = decodeHtmlEntities(textContent);
       cleanText = cleanText.replace(/<code[^>]*>([^<]{1,30})<\/code>/gi, '`$1`');
       cleanText = cleanText.replace(/<[^>]+>/g, '');
-      for (let i = 0; i < 3; i++) {
+      // Repeat sanitization until no further changes
+      let prevText;
+      do {
+        prevText = cleanText;
         cleanText = cleanText
+          .replace(/<script[\s\S]*?<\/script>/gi, '')
           .replace(/<pr<cod?/gi, '')
           .replace(/<pr</gi, '')
           .replace(/<pr/gi, '')
@@ -807,8 +811,9 @@ const QuestionContent = ({ content }: { content: string }) => {
           .replace(/\s*e>\s*/g, ' ')
           .replace(/^>\s*/g, '')
           .replace(/\s*>$/g, '')
-          .replace(/\s+>\s+/g, ' ');
-      }
+          .replace(/\s+>\s+/g, ' ')
+          .replace(/<[^>]+>/g, ''); // remove any remaining tags
+      } while (cleanText !== prevText);
       cleanText = cleanText.replace(/[ \t]+/g, ' ').replace(/\n\s*\n/g, '\n\n').trim();
       if (cleanText) {
         parts.push({ type: 'text', content: cleanText });
@@ -819,7 +824,11 @@ const QuestionContent = ({ content }: { content: string }) => {
   if (parts.length === 0) {
     let cleanContent = fixedContent;
     
-    for (let i = 0; i < 3; i++) {
+    // Repeat sanitization until no further changes
+    let prevContent;
+    do {
+      prevContent = cleanContent;
+        .replace(/<script[\s\S]*?<\/script>/gi, '')
       cleanContent = cleanContent
         .replace(/<pr<cod/gi, '')
         .replace(/<\/cod<\/pr/gi, '')
@@ -838,7 +847,7 @@ const QuestionContent = ({ content }: { content: string }) => {
         .replace(/^>\s*/g, '')
         .replace(/\s*>$/g, '')
         .replace(/\s+>\s+/g, ' ');
-    }
+    } while (cleanContent !== prevContent);
     
     cleanContent = cleanContent
       .replace(/&nbsp;/g, ' ')


### PR DESCRIPTION
Potential fix for [https://github.com/FoushWare/elzatona_web/security/code-scanning/793](https://github.com/FoushWare/elzatona_web/security/code-scanning/793)

The best way to fix this problem is to ensure that dangerous HTML tags like `<script>` are completely removed, even if they appear in malformed or split segments or are recreated following partial replacements.  
This is achieved by repeatedly applying the regular expression replacement until no more changes occur (rather than using a fixed number of iterations).  
Alternatively, using a library such as `sanitize-html` (if allowed by context) would guarantee robust sanitization. Since we cannot assume additional NPM packages, the fix is to replace the existing loop structure for sanitization with a loop that continually applies replacements until the content no longer changes, both in the `cleanText` block and the `cleanContent` block, and to ensure that the `<[^>]+>` pattern or even more restrictive patterns for dangerous tags are fully effective.  
All changes must be made in `apps/website/src/app/free-style-practice/page.tsx` within the blocks shown.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
