### PR TITLE
Potential fix for code scanning alert no. 796: Incomplete multi-character sanitization

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "next": "^14.0.0",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "sanitize-html": "^2.17.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/apps/website/src/components/ProblemSolvingQuestion.tsx
+++ b/apps/website/src/components/ProblemSolvingQuestion.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from 'react';
 import CodeEditor from './CodeEditor';
 import { CheckCircle, XCircle, AlertCircle, Play, Loader2, Code2, Trophy, ChevronRight, Maximize2, Minimize2, Copy, Plus, Lightbulb, BookOpen } from 'lucide-react';
 import { addFlashcard, isInFlashcards, removeFlashcard } from '../lib/flashcards';
+import sanitizeHtml from 'sanitize-html';
 
 interface TestCase {
   input: any | any[];
@@ -146,7 +147,7 @@ export default function ProblemSolvingQuestion({
     if (codeMatch && codeMatch[1]) {
       let code = codeMatch[1];
       code = decodeHtmlEntities(code);
-      code = code.replace(/<[^>]+>/g, '');
+      code = sanitizeHtml(code, { allowedTags: [] }); // Strips all HTML tags
       // Clean up malformed patterns - multiple passes for thorough cleaning
       for (let i = 0; i < 3; i++) {
         code = code


### PR DESCRIPTION
Potential fix for [https://github.com/FoushWare/elzatona_web/security/code-scanning/796](https://github.com/FoushWare/elzatona_web/security/code-scanning/796)

The best fix is to replace the incomplete tag removal with a robust, well-established HTML sanitizer for non-markup code blocks. In the context of React and Node.js, the popular `sanitize-html` npm package is a secure and reliable way to strip dangerous HTML tags and attributes from user input.

Specifically:  
- Import `sanitize-html` at the top.  
- Replace the current regex-based cleanup on line 149 with a call to `sanitizeHtml(code, { allowedTags: [] })`, which removes all HTML tags but preserves plain text, ensuring no residual script tags or other dangerous HTML remains.  
- Optionally, ensure that you use `decodeHtmlEntities` before sanitizing, as currently done.
- For minimal impact, simply replace the mentioned problematic regex removal step, keeping subsequent artifact cleanups as a defense-in-depth measure.

Modifications are strictly within the visible code region:
- `apps/website/src/components/ProblemSolvingQuestion.tsx`
  - Add import for `sanitize-html` at the top.
  - Replace line 149 (`code = code.replace(/<[^>]+>/g, '');`) with usage of `sanitizeHtml`.


---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
