### PR TITLE
Potential fix for code scanning alert no. 799: Incomplete multi-character sanitization

### DIFF
--- a/libs/shared-components/package.json
+++ b/libs/shared-components/package.json
@@ -3,5 +3,8 @@
   "version": "0.0.1",
   "type": "commonjs",
   "main": "./src/index.ts",
-  "types": "./src/index.ts"
+  "types": "./src/index.ts",
+  "dependencies": {
+    "sanitize-html": "^2.17.0"
+}
 }

--- a/libs/shared-components/src/lib/QuestionContent.tsx
+++ b/libs/shared-components/src/lib/QuestionContent.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
-
+import sanitizeHtml from 'sanitize-html';
 // Helper function to determine if content is valid code or should be rendered as text
 // Uses a scoring system to make intelligent decisions
 export const isValidCode = (content: string): { isValid: boolean; score: number; reasons: string[] } => {
@@ -456,7 +456,7 @@ export const QuestionContent = ({ content }: { content: string }) => {
     while (code !== previousCode && iterations < maxIterations) {
       previousCode = code;
       code = decodeHtmlEntities(code);
-      code = code.replace(/<\/?[a-zA-Z][a-zA-Z0-9]*(?:\s+[^>]*)?>/gi, '');
+      code = sanitizeHtml(code, { allowedTags: [], allowedAttributes: {} });
       iterations++;
     }
     
@@ -498,7 +498,7 @@ export const QuestionContent = ({ content }: { content: string }) => {
         .replace(/(\w+)\s*&lt;\s*(\d+)\s*&gt;/g, '$1 < $2 >')
         .replace(/(\w+)\s*&lt;\s*(\d+)/g, '$1 < $2')
         .replace(/(\d+)\s*&gt;/g, '$1 >')
-        .replace(/<\/?[a-zA-Z][a-zA-Z0-9]*(?:\s+[^>]*)?>/gi, '')
+        // HTML tag stripping now handled by sanitizeHtml above
         .replace(/^>\s*/g, '')
         .replace(/\s*>$/g, '')
         .replace(/\s+>\s+/g, ' ');


### PR DESCRIPTION
Potential fix for [https://github.com/FoushWare/elzatona_web/security/code-scanning/799](https://github.com/FoushWare/elzatona_web/security/code-scanning/799)

**General fix approach:**  
Replace the insecure custom HTML tag removal logic with a well-tested sanitization library (such as `sanitize-html`). Libraries like `sanitize-html` are specifically designed to robustly remove unwanted tags (like `<script>`) and attributes, resist evasion attempts, and handle corner cases that custom regex-based solutions will miss.

**Detailed change:**  
- Import `sanitize-html` at the top of the file.
- Identify the region where `.replace(/<\/?[a-zA-Z][a-zA-Z0-9]*(?:\s+[^>]*)?>/gi, '')` (line 459 and 501) is used (and possibly other HTML entity replacements).
- Replace the multi-pass HTML tag removal logic by passing the `code` string through `sanitizeHtml`, configured to disallow all HTML tags (unless you want to allow certain safe formatting).
- This should be done after the initial extraction (`code = fixedHtml.substring(...)`) and before any further decoding or entity replacement logic.
- Remove iterative and repeated regex replacements related to HTML tag removal, since the sanitization library will handle it robustly.

**What's needed:**  
- Add an import for `sanitize-html`.
- Replace the problematic tag-stripping regex logic with a direct call to `sanitizeHtml`.
- Optionally, configure `sanitizeHtml` to strip all tags or allow only a safe subset (depending on requirements).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
