### PR TITLE
Potential fix for code scanning alert no. 794: Incomplete multi-character sanitization

### DIFF
--- a/apps/website/src/app/guided-practice/page.tsx
+++ b/apps/website/src/app/guided-practice/page.tsx
@@ -216,7 +216,12 @@ const cleanOptionText = (text: string): string => {
   });
   
   // Step 5: Remove any remaining HTML tags (but preserve backtick-wrapped content)
-  cleaned = cleaned.replace(/<[^>]+>/g, '');
+  // Remove all HTML tags by repeatedly applying the regex until none remain
+  let prevCleaned;
+  do {
+    prevCleaned = cleaned;
+    cleaned = cleaned.replace(/<[^>]+>/g, '');
+  } while (cleaned !== prevCleaned);
   
   // Step 4: Fix common malformed patterns from HTML parsing issues
   // First, handle the specific e> artifact pattern (from </code> tags)


### PR DESCRIPTION
Potential fix for [https://github.com/FoushWare/elzatona_web/security/code-scanning/794](https://github.com/FoushWare/elzatona_web/security/code-scanning/794)

The best fix without changing existing functionality is to apply the regular expression replacement repeatedly until no more replacements occur. This can be implemented by wrapping the replacement in a loop that continues as long as changes are made (i.e., the output changes between iterations). The ideal approach is to replace the single call to `cleaned.replace(/<[^>]+>/g, '')` at line 219 with a loop that runs until all tags are removed.

This requires:
- Replacing line 219 in file `apps/website/src/app/guided-practice/page.tsx` to apply the regex repeatedly.
No new imports or helper functions are needed for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
