### PR TITLE
Potential fix for code scanning alert no. 795: Incomplete multi-character sanitization

### DIFF
--- a/apps/website/src/components/ProblemSolvingQuestion.tsx
+++ b/apps/website/src/components/ProblemSolvingQuestion.tsx
@@ -101,7 +101,12 @@ export default function ProblemSolvingQuestion({
       let code = preCodeMatch[1];
       // Decode entities and remove HTML tags
       code = decodeHtmlEntities(code);
-      code = code.replace(/<[^>]+>/g, '');
+      // Remove HTML tags robustly: repeatedly until none remain
+      let previousCode;
+      do {
+        previousCode = code;
+        code = code.replace(/<[^>]+>/g, '');
+      } while (code !== previousCode);
       // Clean up malformed patterns - multiple passes for thorough cleaning
       for (let i = 0; i < 3; i++) {
         code = code


### PR DESCRIPTION
Potential fix for [https://github.com/FoushWare/elzatona_web/security/code-scanning/795](https://github.com/FoushWare/elzatona_web/security/code-scanning/795)

The main issue is using `.replace(/<[^>]+>/g, '')` only once to remove HTML tags, which does not handle cases where new tags may appear after initial replacements. To robustly sanitize, we should either use a well-tested HTML sanitization library (such as `sanitize-html` or DOMPurify), or, if limited to manual replacement, apply the tag removal regex repeatedly until no matches remain. This ensures all fragments of HTML tags—including those that may be revealed after previous replacements—are removed. 

Edit the code in `apps/website/src/components/ProblemSolvingQuestion.tsx`, specifically line 104 where HTML tags are removed, to apply this replacement in a loop, stopping only when the string remains the same between passes. If external libraries cannot be assumed present, use the repeated replacement approach.

It may be appropriate to wrap this with a helper function (e.g., `removeHtmlTags`), but we will only add code within the provided snippet as per the instructions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
