### PR TITLE
Potential fix for code scanning alert no. 797: Incomplete multi-character sanitization

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "next": "^14.0.0",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "sanitize-html": "^2.17.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/apps/website/src/lib/markdown-question-parser.ts
+++ b/apps/website/src/lib/markdown-question-parser.ts
@@ -2,6 +2,7 @@
 // Parses markdown content to extract questions in various formats
 
 import { BulkQuestionData } from './unified-question-schema';
+import sanitizeHtml from 'sanitize-html';
 
 export interface MarkdownQuestion {
   title: string;
@@ -431,8 +432,7 @@ export class MarkdownQuestionParser {
       // Extract content between <p> tags, removing HTML tags
       const pMatch = detailsMatch[0].match(/<p>([\s\S]*?)<\/p>/i);
       if (pMatch) {
-        return pMatch[1]
-          .replace(/<[^>]*>/g, '') // Remove HTML tags
+        return sanitizeHtml(pMatch[1], { allowedTags: [], allowedAttributes: {} }) // Remove all HTML tags and attributes safely
           .replace(/\n\s*\n/g, '\n') // Clean up extra whitespace
           .trim();
       }


### PR DESCRIPTION
Potential fix for [https://github.com/FoushWare/elzatona_web/security/code-scanning/797](https://github.com/FoushWare/elzatona_web/security/code-scanning/797)

To fully address the incomplete multi-character sanitization exposed here, the best solution is to replace the ad-hoc regex-based stripping of HTML tags (on line 435) with a mature sanitization library. The `sanitize-html` package is widely used for this purpose in Node.js/TypeScript projects. By using `sanitize-html`, we ensure that all malicious HTML elements, especially `<script>` tags and any complex nested tags, are properly removed.

The changes required:
- Add an import for the `sanitize-html` package at the top of the file.
- Replace the `.replace(/<[^>]*>/g, '')` on line 435 with a call to `sanitizeHtml` to strip unsafe tags.
- Optionally, keep the rest of the transformations (like removing extra whitespace and trimming).
- Ensure the output remains text-only or free from unwanted HTML, consistent with prior behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
