### PR TITLE
Potential fix for code scanning alert no. 798: Incomplete multi-character sanitization

### DIFF
--- a/libs/shared-components/package.json
+++ b/libs/shared-components/package.json
@@ -3,5 +3,8 @@
   "version": "0.0.1",
   "type": "commonjs",
   "main": "./src/index.ts",
-  "types": "./src/index.ts"
+  "types": "./src/index.ts",
+  "dependencies": {
+    "sanitize-html": "^2.17.0"
+}
 }

--- a/libs/shared-components/src/lib/QuestionContent.tsx
+++ b/libs/shared-components/src/lib/QuestionContent.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
-
+import sanitizeHtml from 'sanitize-html';
 // Helper function to determine if content is valid code or should be rendered as text
 // Uses a scoring system to make intelligent decisions
 export const isValidCode = (content: string): { isValid: boolean; score: number; reasons: string[] } => {
@@ -449,19 +449,11 @@ export const QuestionContent = ({ content }: { content: string }) => {
     
     code = decodeHtmlEntities(code);
     
-    let previousCode = '';
-    let iterations = 0;
-    const maxIterations = 20;
-    
-    while (code !== previousCode && iterations < maxIterations) {
-      previousCode = code;
-      code = decodeHtmlEntities(code);
-      code = code.replace(/<\/?[a-zA-Z][a-zA-Z0-9]*(?:\s+[^>]*)?>/gi, '');
-      iterations++;
-    }
-    
+    // Use sanitize-html to remove all HTML tags, especially <script> and others
+    code = sanitizeHtml(code, { allowedTags: [], allowedAttributes: {} });
     code = decodeHtmlEntities(code);
     
+    // Still apply post-processing for any peculiar patterns, if needed
     for (let pass = 0; pass < 3; pass++) {
       code = code
         .replace(/e>e>e>/g, '')


### PR DESCRIPTION
Potential fix for [https://github.com/FoushWare/elzatona_web/security/code-scanning/798](https://github.com/FoushWare/elzatona_web/security/code-scanning/798)

The safest and simplest fix is to use a well-maintained HTML sanitization library that reliably removes unwanted HTML tags—especially script tags—from input. The npm package `sanitize-html` is a popular choice for this use case and is well supported. To implement this fix directly in `libs/shared-components/src/lib/QuestionContent.tsx`, add an import for `sanitize-html`, and replace the repeated regex sanitization logic (lines 459-463 and repeating passes on 467+) with a sanitization call. This will robustly eliminate script tags and other dangerous HTML constructs. The rest of the logic (entity decoding) can be retained as needed before or after sanitization.

You will need to:

- Add an import statement for `sanitize-html` at the top of the file.
- Replace the loop (lines 452-463) and any subsequent regex-based HTML tag removal (including passes like 467) with a single call to `sanitizeHtml(code, {allowedTags: []})` to fully strip all HTML tags.
- Confirm surrounding logic still works (entity decoding, etc.).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
