### PR TITLE
Potential fix for code scanning alert no. 800: Incomplete multi-character sanitization

### DIFF
--- a/libs/shared-components/package.json
+++ b/libs/shared-components/package.json
@@ -3,5 +3,8 @@
   "version": "0.0.1",
   "type": "commonjs",
   "main": "./src/index.ts",
-  "types": "./src/index.ts"
+  "types": "./src/index.ts",
+  "dependencies": {
+    "sanitize-html": "^2.17.0"
+}
 }

--- a/libs/shared-components/src/lib/QuestionContent.tsx
+++ b/libs/shared-components/src/lib/QuestionContent.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import sanitizeHtml from 'sanitize-html';
 
 // Helper function to determine if content is valid code or should be rendered as text
 // Uses a scoring system to make intelligent decisions
@@ -578,7 +579,7 @@ export const QuestionContent = ({ content }: { content: string }) => {
     if (!alreadyCaptured && malformedMatch[1]) {
       let code = malformedMatch[1];
       code = decodeHtmlEntities(code);
-      code = code.replace(/<[^>]+>/g, '');
+      code = sanitizeHtml(code, { allowedTags: [], allowedAttributes: {} });
       for (let i = 0; i < 3; i++) {
         code = code
           .replace(/e>e>e>/g, '')


### PR DESCRIPTION
Potential fix for [https://github.com/FoushWare/elzatona_web/security/code-scanning/800](https://github.com/FoushWare/elzatona_web/security/code-scanning/800)

The best fix for this problem is to use a well-established sanitization library, such as `sanitize-html`, which safely and thoroughly strips out (or escapes) all HTML tags and dangerous content, including script tags and malformed tags, regardless of complexity. This prevents any possibility of HTML element injection vulnerabilities.

**Detailed steps:**

- Install the `sanitize-html` npm package.
- Import `sanitize-html` at the top of the file (`libs/shared-components/src/lib/QuestionContent.tsx`).
- Replace the current unsafe `.replace(/<[^>]+>/g, '')` call on line 581 with `sanitizeHtml(code, { allowedTags: [], allowedAttributes: {} })`, which strips all HTML tags/attributes.
- Ensure that this operation does not break the existing functionality (since `.replace(/<[^>]+>/g, '')` is supposed to remove HTML tags, the new sanitizer will do the same, but more thoroughly).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
