### PR TITLE
Potential fix for code scanning alert no. 801: Incomplete multi-character sanitization

### DIFF
--- a/libs/shared-components/src/lib/QuestionContent.tsx
+++ b/libs/shared-components/src/lib/QuestionContent.tsx
@@ -635,7 +635,12 @@ export const QuestionContent = ({ content }: { content: string }) => {
       if (textContent.trim()) {
         let cleanText = decodeHtmlEntities(textContent);
         cleanText = cleanText.replace(/<code[^>]*>([^<]{1,30})<\/code>/gi, '`$1`');
-        cleanText = cleanText.replace(/<[^>]+>/g, '');
+        // Repeat tag removal until no more matches
+        let previousText;
+        do {
+          previousText = cleanText;
+          cleanText = cleanText.replace(/<[^>]+>/g, '');
+        } while (cleanText !== previousText);
         for (let i = 0; i < 3; i++) {
           cleanText = cleanText
             .replace(/<pr<cod?/gi, '')


### PR DESCRIPTION
Potential fix for [https://github.com/FoushWare/elzatona_web/security/code-scanning/801](https://github.com/FoushWare/elzatona_web/security/code-scanning/801)

To robustly prevent residual HTML tags (including `<script>` or other dangerous tags) after potentially merging fragments, the replacement should be performed repeatedly until no further matches are found. This can be achieved by wrapping the `.replace()` call in a loop (do/while), which re-applies the same regex until the string ceases to change. There is no need to introduce a third-party HTML sanitization library here unless HTML rendering is involved; the task seems to be full tag-stripping. The recommended fix is to replace the single-pass `cleanText.replace(/<[^>]+>/g, '')` with a loop that applies the pattern until all possible tags have been removed.

Edit only the relevant block in libs/shared-components/src/lib/QuestionContent.tsx, specifically around line 638.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
