### PR TITLE
Potential fix for code scanning alert no. 802: Incomplete multi-character sanitization

### DIFF
--- a/libs/shared-components/package.json
+++ b/libs/shared-components/package.json
@@ -3,5 +3,8 @@
   "version": "0.0.1",
   "type": "commonjs",
   "main": "./src/index.ts",
-  "types": "./src/index.ts"
+  "types": "./src/index.ts",
+  "dependencies": {
+    "sanitize-html": "^2.17.0"
+}
 }

--- a/libs/shared-components/src/lib/QuestionContent.tsx
+++ b/libs/shared-components/src/lib/QuestionContent.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import sanitizeHtml from 'sanitize-html';
 
 // Helper function to determine if content is valid code or should be rendered as text
 // Uses a scoring system to make intelligent decisions
@@ -694,7 +695,7 @@ export const QuestionContent = ({ content }: { content: string }) => {
     if (textContent.trim()) {
       let cleanText = decodeHtmlEntities(textContent);
       cleanText = cleanText.replace(/<code[^>]*>([^<]{1,30})<\/code>/gi, '`$1`');
-      cleanText = cleanText.replace(/<[^>]+>/g, '');
+      cleanText = sanitizeHtml(cleanText, { allowedTags: [], allowedAttributes: {} });
       for (let i = 0; i < 3; i++) {
         cleanText = cleanText
           .replace(/<pr<cod?/gi, '')


### PR DESCRIPTION
Potential fix for [https://github.com/FoushWare/elzatona_web/security/code-scanning/802](https://github.com/FoushWare/elzatona_web/security/code-scanning/802)

**General Solution:**  
Rather than manually removing HTML tags using regex, which is error-prone and incomplete, use a trusted library for sanitization, such as `sanitize-html`. This will robustly remove all dangerous or undesired tags and attributes, handling edge cases like overlapping/nested/fragmented tags.

**Detailed Steps:**  
- Install and import a trusted sanitization library (`sanitize-html` is a standard choice with good coverage and configurability).
- In the region where `cleanText` is generated (line 697), replace ad-hoc tag-removal with a call to `sanitizeHtml`, using default settings or a conservative whitelist (possibly allowing no tags, to match the spirit of the original code).
- Review, but likely keep, the subsequent whitespace/formatting clean-up (line 718).
- Add library import at the top of the file.

**Needed changes:**  
- Add import for `sanitize-html` at the top.
- Change line 697 from `cleanText = cleanText.replace(/<[^>]+>/g, '')` to `cleanText = sanitizeHtml(cleanText, { allowedTags: [], allowedAttributes: {} });`.
- Ensure `sanitizeHtml` is available to use.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
