### PR TITLE
Potential fix for code scanning alert no. 803: Incomplete multi-character sanitization

### DIFF
--- a/libs/shared-components/src/lib/QuestionContent.tsx
+++ b/libs/shared-components/src/lib/QuestionContent.tsx
@@ -725,8 +725,16 @@ export const QuestionContent = ({ content }: { content: string }) => {
   if (parts.length === 0) {
     let cleanContent = fixedContent;
     
-    for (let i = 0; i < 3; i++) {
+    // Repeat sanitation until no further changes occur
+    let prevContent;
+    do {
+      prevContent = cleanContent;
       cleanContent = cleanContent
+        // Remove script tags and their content (fragmented and obfuscated variations)
+        .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+        .replace(/<script[^>]*>/gi, '')
+        .replace(/<\/script>/gi, '')
+        // Remove other risky fragments
         .replace(/<pr<cod/gi, '')
         .replace(/<\/cod<\/pr/gi, '')
         .replace(/<pr</gi, '')
@@ -744,7 +752,7 @@ export const QuestionContent = ({ content }: { content: string }) => {
         .replace(/^>\s*/g, '')
         .replace(/\s*>$/g, '')
         .replace(/\s+>\s+/g, ' ');
-    }
+    } while (cleanContent !== prevContent);
     
     cleanContent = cleanContent
       .replace(/&nbsp;/g, ' ')


### PR DESCRIPTION
Potential fix for [https://github.com/FoushWare/elzatona_web/security/code-scanning/803](https://github.com/FoushWare/elzatona_web/security/code-scanning/803)

The best way to fix this incomplete multi-character sanitization is to use a proven sanitization library such as `sanitize-html`, which robustly removes unwanted HTML tags and dangerous fragments. Since this is a React project, another simple defense for text output is ensuring that resulting content is never rendered as raw HTML, but as plain text (e.g., via JSX, which escapes text).

If using a library is not an option, then the fixed code should repeatedly remove risky tags, specifically eliminating `<script>` elements, and finally remove or escape residual `<` and `>` to prevent accidental HTML injection. This can be achieved by adding a loop to re-run the replacements until no changes occur (idempotent sanitization), and/or by adding explicit code to ensure `<script>` tags (possibly fragmented) are removed.

To be maximally safe:

- Before line 753 (or after), exhaustively remove all `<script>` tags and stray `<` or `>`.
- Use a loop applying replacements until no more changes occur (`do { ... } while (old !== new)`).
- If permitted, use `sanitize-html` npm package. If not, do the looped replaces inline.

Required changes:
- Insert a do-while loop for multi-character replacements instead of `for (let i = 0; i < 3; i++)`.
- Optionally add or import `sanitize-html` and use it for the final clean step.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
