### PR TITLE
Potential fix for code scanning alert no. 804: Incomplete multi-character sanitization

### DIFF
--- a/scripts/fix-option-text.js
+++ b/scripts/fix-option-text.js
@@ -39,7 +39,12 @@ const cleanOptionText = (text) => {
   cleaned = cleaned.replace(/<code[^>]*>([^<]+)<\/code>/gi, (_, codeContent) => {
     return `\`${decodeHtmlEntities(codeContent).trim()}\``;
   });
-  cleaned = cleaned.replace(/<[^>]+>/g, '');
+  // Remove all HTML tags reliably by repeatedly applying regex
+  let prev;
+  do {
+    prev = cleaned;
+    cleaned = cleaned.replace(/<[^>]+>/g, '');
+  } while (cleaned !== prev);
   
   // First, handle the specific e> artifact pattern
   cleaned = cleaned.replace(/(\w+)e>/g, '$1');


### PR DESCRIPTION
Potential fix for [https://github.com/FoushWare/elzatona_web/security/code-scanning/804](https://github.com/FoushWare/elzatona_web/security/code-scanning/804)

To robustly prevent incomplete removal of HTML tags (e.g. `<script>` fragments), the code should either:
- Use a well-tested HTML sanitization library such as `sanitize-html`.
- Or, if introducing a dependency isn’t possible, repeatedly apply the tag-stripping regular expression until there are no more tags left (i.e., as long as the output keeps changing).

Because you cannot assume the use of a new dependency given the code shown, the best fix here is to apply the tag-removal regex (`/<[^>]+>/g`) in a loop until no more matches are found (i.e., the string stops changing). This is more reliable than a fixed number of passes.

Edit line 42 to apply `cleaned.replace(/<[^>]+>/g, '')` as a loop, not a one-off. This can be done by using a do-while loop, similarly to the earlier example for comment removal.

The only file to edit is `scripts/fix-option-text.js`, in the definition of `cleanOptionText`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
