### PR TITLE
Security: Remove Stripe secret keys and test credentials

### DIFF
--- a/secrets-replacements.txt
+++ b/secrets-replacements.txt
@@ -1,10 +1,2 @@
 # Replace exact literal secrets found in repo history
-sk_live_1234567890abcdef==>REDACTED_SK
-sk_live_1234567890==>REDACTED_SK
-test-service-role-key==>REDACTED_TEST_KEY
-test-key==>REDACTED_TEST_KEY
-test-anon-key==>REDACTED_TEST_KEY
-mypassword123==>REDACTED_SECRET
-"sk_live_1234567890"==>"REDACTED_SK"
-"sk_live_1234567890abcdef"==>"REDACTED_SK"
 REDACTED_PLACEHOLDER==>REDACTED_PLACEHOLDER


### PR DESCRIPTION
Removes all exposed Stripe secret keys and sensitive test credentials from secrets-replacements.txt.\nAddresses: #7615, #7616, #7617, #7618.