### PR TITLE
fix(sonar): reduce duplication in editor utils and harden decoding

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,35 @@
+language: "en-US"
+
+tone_instructions: >
+  Review this Nx monorepo with practical, low-noise feedback. Prioritize correctness,
+  security, performance, and maintainability. Avoid nitpicks unless they affect
+  readability or defects.
+
+reviews:
+  high_level_summary: true
+  review_status: true
+  collapse_walkthrough: false
+  poem: false
+
+  auto_review:
+    enabled: true
+    drafts: false
+
+  path_filters:
+    - "!**/node_modules/**"
+    - "!**/.next/**"
+    - "!**/dist/**"
+    - "!**/build/**"
+    - "!**/coverage/**"
+    - "!**/playwright-report/**"
+    - "!**/test-results/**"
+    - "!**/.nx/**"
+    - "!**/.scannerwork/**"
+    - "!**/codeql-database/**"
+    - "!**/*.lock"
+    - "!**/pnpm-lock.yaml"
+    - "!**/yarn.lock"
+    - "!**/package-lock.json"
+
+chat:
+  auto_reply: true

--- a/libs/common-ui/src/admin/editors/FrontendTaskEditorUtils.ts
+++ b/libs/common-ui/src/admin/editors/FrontendTaskEditorUtils.ts
@@ -29,20 +29,36 @@ export const isReactCode = (code: string): boolean => {
 
 export const cleanReactCode = (reactCode: string): string => {
   const lines = reactCode.split("\n");
+  let inImportBlock = false;
   const withoutImports = lines.filter((line) => {
     const trimmedLine = line.trimStart();
-    return !trimmedLine.startsWith("import ");
+
+    if (inImportBlock) {
+      if (trimmedLine.includes(" from ") || trimmedLine.endsWith(";")) {
+        inImportBlock = false;
+      }
+      return false;
+    }
+
+    if (trimmedLine.startsWith("import ")) {
+      inImportBlock =
+        !trimmedLine.includes(" from ") && !trimmedLine.endsWith(";");
+      return false;
+    }
+
+    return true;
   });
 
   const withoutExports = withoutImports.map((line) => {
-    const trimmedLine = line.trimStart();
+    const leadingWhitespace = /^\s*/.exec(line)?.[0] ?? "";
+    const trimmedLine = line.slice(leadingWhitespace.length);
 
     if (trimmedLine.startsWith("export default ")) {
-      return line.replace("export default ", "");
+      return leadingWhitespace + trimmedLine.replace(/^export default\s+/, "");
     }
 
     if (trimmedLine.startsWith("export ")) {
-      return line.replace("export ", "");
+      return leadingWhitespace + trimmedLine.replace(/^export\s+/, "");
     }
 
     return line;

--- a/libs/common-ui/src/admin/editors/FrontendTaskEditorUtils.ts
+++ b/libs/common-ui/src/admin/editors/FrontendTaskEditorUtils.ts
@@ -2,141 +2,20 @@ import {
   AdminFrontendTaskFile,
   AdminFrontendTaskFormData,
 } from "@elzatona/types";
+import type { EditorFileNode as FileNode } from "./sharedEditorFileUtils";
 
-interface FileNode {
-  id: string;
-  name: string;
-  type: "file" | "folder";
-  children?: FileNode[];
-  content?: string;
-  fileType?: string;
-  isEntryPoint?: boolean;
-}
-
-// File management helper functions
-export const createFileNode = (
-  name: string,
-  type: string,
-  content: string = "",
-): FileNode => {
-  const id = `file_${Date.now()}`;
-  return {
-    id,
-    name,
-    type: "file",
-    content,
-    fileType: type,
-  };
-};
-
-export const addFileToTree = (
-  fileTree: FileNode[],
-  newFile: FileNode,
-): FileNode[] => {
-  return fileTree.map((folder) => {
-    if (folder.type === "folder" && folder.children) {
-      return {
-        ...folder,
-        children: [...folder.children, newFile],
-      };
-    }
-    return folder;
-  });
-};
-
-export const removeFileFromTree = (
-  fileTree: FileNode[],
-  fileId: string,
-): FileNode[] => {
-  return fileTree.map((folder) => {
-    if (folder.type === "folder" && folder.children) {
-      return {
-        ...folder,
-        children: folder.children.filter((file) => file.id !== fileId),
-      };
-    }
-    return folder;
-  });
-};
-
-export const updateFileInTree = (
-  fileTree: FileNode[],
-  fileId: string,
-  content: string,
-): FileNode[] => {
-  return fileTree.map((folder) => {
-    if (folder.type === "folder" && folder.children) {
-      return {
-        ...folder,
-        children: folder.children.map((file) =>
-          file.id === fileId ? { ...file, content } : file,
-        ),
-      };
-    }
-    return folder;
-  });
-};
-
-// File UI and content helper functions
-export const getFileIcon = (fileType: string) => {
-  switch (fileType) {
-    case "tsx":
-    case "jsx":
-      return "blue";
-    case "css":
-      return "purple";
-    case "html":
-      return "orange";
-    case "js":
-      return "yellow";
-    case "json":
-      return "green";
-    default:
-      return "gray";
-  }
-};
-
-export const getFileById = (openFiles: any[], fileId: string) => {
-  return openFiles.find((file) => file.id === fileId);
-};
-
-export const getCurrentFileContent = (
-  openFiles: any[],
-  activeFile: string | null,
-) => {
-  if (!activeFile) return "";
-  const file = getFileById(openFiles, activeFile);
-  return file?.content || "";
-};
-
-export const setCurrentFileContent = (
-  openFiles: any[],
-  activeFile: string | null,
-  content: string,
-) => {
-  if (!activeFile) return openFiles;
-  return openFiles.map((file) =>
-    file.id === activeFile ? { ...file, content } : file,
-  );
-};
-
-export const getLanguageForType = (fileType: string) => {
-  switch (fileType) {
-    case "tsx":
-    case "jsx":
-      return "typescript";
-    case "css":
-      return "css";
-    case "html":
-      return "html";
-    case "js":
-      return "javascript";
-    case "json":
-      return "json";
-    default:
-      return "plaintext";
-  }
-};
+export {
+  addFileToTree,
+  copyToClipboard,
+  createFileNode,
+  getCurrentFileContent,
+  getFileById,
+  getFileIcon,
+  getLanguageForType,
+  removeFileFromTree,
+  setCurrentFileContent,
+  updateFileInTree,
+} from "./sharedEditorFileUtils";
 
 // Code generation helper functions
 export const isReactCode = (code: string): boolean => {
@@ -149,15 +28,27 @@ export const isReactCode = (code: string): boolean => {
 };
 
 export const cleanReactCode = (reactCode: string): string => {
-  // Remove import statements
-  let cleanedCode = reactCode
-    .replaceAll(/import\s+.*?from\s+['"][^'"]*['"];?\s*/g, "")
-    .replaceAll(/import\s+.*?;/g, "");
+  const lines = reactCode.split("\n");
+  const withoutImports = lines.filter((line) => {
+    const trimmedLine = line.trimStart();
+    return !trimmedLine.startsWith("import ");
+  });
 
-  // Remove export statements
-  cleanedCode = cleanedCode
-    .replaceAll(/export\s+default\s+/g, "")
-    .replaceAll(/export\s+/g, "");
+  const withoutExports = withoutImports.map((line) => {
+    const trimmedLine = line.trimStart();
+
+    if (trimmedLine.startsWith("export default ")) {
+      return line.replace("export default ", "");
+    }
+
+    if (trimmedLine.startsWith("export ")) {
+      return line.replace("export ", "");
+    }
+
+    return line;
+  });
+
+  let cleanedCode = withoutExports.join("\n");
 
   // Remove semicolons at the end of lines
   cleanedCode = cleanedCode.replaceAll(/;(\s*$)/gm, "$1");
@@ -168,13 +59,6 @@ export const cleanReactCode = (reactCode: string): string => {
 export const generateConsoleCaptureCode = (): string => {
   return `
     // Console capture
-    const originalLog = dried = console.log(");
-    const originalError = x.error;
-    const originalWarn =一金.warn;
-    const originalInfo Info = console.info    const messages = = [];
-    
-   意义的.log = function    const messages = [];
-    
     const originalLog = console.log;
     const originalError = console.error;
     const originalWarn = console.warn;
@@ -350,16 +234,6 @@ export const createTaskData = (
     ...formData,
     files,
   };
-};
-
-export const copyToClipboard = async (content: string): Promise<void> => {
-  try {
-    await navigator.clipboard.writeText(content);
-    return;
-  } catch (err) {
-    console.error("Failed to copy code:", err);
-    throw err;
-  }
 };
 
 export const getCategoryIcon = (category: string) => {

--- a/libs/common-ui/src/admin/editors/ProblemSolvingEditorUtils.ts
+++ b/libs/common-ui/src/admin/editors/ProblemSolvingEditorUtils.ts
@@ -1,138 +1,18 @@
 import { ProblemSolvingTaskFormData, TestCase } from "@elzatona/types";
+import type { EditorFileNode as FileNode } from "./sharedEditorFileUtils";
 
-interface FileNode {
-  id: string;
-  name: string;
-  type: "file" | "folder";
-  children?: FileNode[];
-  content?: string;
-  fileType?: string;
-}
-
-// File management helper functions
-export const createFileNode = (
-  name: string,
-  type: string,
-  content: string = "",
-): FileNode => {
-  const id = `file_${Date.now()}`;
-  return {
-    id,
-    name,
-    type: "file",
-    content,
-    fileType: type,
-  };
-};
-
-export const addFileToTree = (
-  fileTree: FileNode[],
-  newFile: FileNode,
-): FileNode[] => {
-  return fileTree.map((folder) => {
-    if (folder.type === "folder" && folder.children) {
-      return {
-        ...folder,
-        children: [...folder.children, newFile],
-      };
-    }
-    return folder;
-  });
-};
-
-export const removeFileFromTree = (
-  fileTree: FileNode[],
-  fileId: string,
-): FileNode[] => {
-  return fileTree.map((folder) => {
-    if (folder.type === "folder" && folder.children) {
-      return {
-        ...folder,
-        children: folder.children.filter((file) => file.id !== fileId),
-      };
-    }
-    return folder;
-  });
-};
-
-export const updateFileInTree = (
-  fileTree: FileNode[],
-  fileId: string,
-  content: string,
-): FileNode[] => {
-  return fileTree.map((folder) => {
-    if (folder.type === "folder" && folder.children) {
-      return {
-        ...folder,
-        children: folder.children.map((file) =>
-          file.id === fileId ? { ...file, content } : file,
-        ),
-      };
-    }
-    return folder;
-  });
-};
-
-// File UI helper functions
-export const getFileIcon = (fileType: string) => {
-  switch (fileType) {
-    case "tsx":
-    case "jsx":
-      return "blue";
-    case "css":
-      return "purple";
-    case "html":
-      return "orange";
-    case "js":
-      return "yellow";
-    case "json":
-      return "green";
-    default:
-      return "gray";
-  }
-};
-
-export const getFileById = (openFiles: any[], fileId: string) => {
-  return openFiles.find((file) => file.id === fileId);
-};
-
-export const getCurrentFileContent = (
-  openFiles: any[],
-  activeFile: string | null,
-) => {
-  if (!activeFile) return "";
-  const file = getFileById(openFiles, activeFile);
-  return file?.content || "";
-};
-
-export const setCurrentFileContent = (
-  openFiles: any[],
-  activeFile: string | null,
-  content: string,
-) => {
-  if (!activeFile) return openFiles;
-  return openFiles.map((file) =>
-    file.id === activeFile ? { ...file, content } : file,
-  );
-};
-
-export const getLanguageForType = (fileType: string) => {
-  switch (fileType) {
-    case "tsx":
-    case "jsx":
-      return "typescript";
-    case "css":
-      return "css";
-    case "html":
-      return "html";
-    case "js":
-      return "javascript";
-    case "json":
-      return "json";
-    default:
-      return "plaintext";
-  }
-};
+export {
+  addFileToTree,
+  copyToClipboard,
+  createFileNode,
+  getCurrentFileContent,
+  getFileById,
+  getFileIcon,
+  getLanguageForType,
+  removeFileFromTree,
+  setCurrentFileContent,
+  updateFileInTree,
+} from "./sharedEditorFileUtils";
 
 // Test case helper functions
 export const createTestCase = (): TestCase => ({
@@ -168,16 +48,6 @@ export const createTaskData = (
   return {
     ...formData,
   };
-};
-
-export const copyToClipboard = async (content: string): Promise<void> => {
-  try {
-    await navigator.clipboard.writeText(content);
-    return;
-  } catch (err) {
-    console.error("Failed to copy code:", err);
-    throw err;
-  }
 };
 
 // Dynamic field helper functions

--- a/libs/common-ui/src/admin/editors/sharedEditorFileUtils.ts
+++ b/libs/common-ui/src/admin/editors/sharedEditorFileUtils.ts
@@ -1,0 +1,142 @@
+export interface EditorFileNode {
+  id: string;
+  name: string;
+  type: "file" | "folder";
+  children?: EditorFileNode[];
+  content?: string;
+  fileType?: string;
+  isEntryPoint?: boolean;
+}
+
+export const createFileNode = (
+  name: string,
+  type: string,
+  content: string = "",
+): EditorFileNode => {
+  const id = `file_${Date.now()}`;
+  return {
+    id,
+    name,
+    type: "file",
+    content,
+    fileType: type,
+  };
+};
+
+export const addFileToTree = (
+  fileTree: EditorFileNode[],
+  newFile: EditorFileNode,
+): EditorFileNode[] => {
+  return fileTree.map((folder) => {
+    if (folder.type === "folder" && folder.children) {
+      return {
+        ...folder,
+        children: [...folder.children, newFile],
+      };
+    }
+    return folder;
+  });
+};
+
+export const removeFileFromTree = (
+  fileTree: EditorFileNode[],
+  fileId: string,
+): EditorFileNode[] => {
+  return fileTree.map((folder) => {
+    if (folder.type === "folder" && folder.children) {
+      return {
+        ...folder,
+        children: folder.children.filter((file) => file.id !== fileId),
+      };
+    }
+    return folder;
+  });
+};
+
+export const updateFileInTree = (
+  fileTree: EditorFileNode[],
+  fileId: string,
+  content: string,
+): EditorFileNode[] => {
+  return fileTree.map((folder) => {
+    if (folder.type === "folder" && folder.children) {
+      return {
+        ...folder,
+        children: folder.children.map((file) =>
+          file.id === fileId ? { ...file, content } : file,
+        ),
+      };
+    }
+    return folder;
+  });
+};
+
+export const getFileIcon = (fileType: string) => {
+  switch (fileType) {
+    case "tsx":
+    case "jsx":
+      return "blue";
+    case "css":
+      return "purple";
+    case "html":
+      return "orange";
+    case "js":
+      return "yellow";
+    case "json":
+      return "green";
+    default:
+      return "gray";
+  }
+};
+
+export const getFileById = (openFiles: any[], fileId: string) => {
+  return openFiles.find((file) => file.id === fileId);
+};
+
+export const getCurrentFileContent = (
+  openFiles: any[],
+  activeFile: string | null,
+) => {
+  if (!activeFile) return "";
+  const file = getFileById(openFiles, activeFile);
+  return file?.content || "";
+};
+
+export const setCurrentFileContent = (
+  openFiles: any[],
+  activeFile: string | null,
+  content: string,
+) => {
+  if (!activeFile) return openFiles;
+  return openFiles.map((file) =>
+    file.id === activeFile ? { ...file, content } : file,
+  );
+};
+
+export const getLanguageForType = (fileType: string) => {
+  switch (fileType) {
+    case "tsx":
+    case "jsx":
+      return "typescript";
+    case "css":
+      return "css";
+    case "html":
+      return "html";
+    case "js":
+      return "javascript";
+    case "json":
+      return "json";
+    default:
+      return "plaintext";
+  }
+};
+
+export const copyToClipboard = async (content: string): Promise<void> => {
+  try {
+    await navigator.clipboard.writeText(content);
+    return;
+  } catch (err) {
+    console.error("Failed to copy code:", err);
+    throw err;
+  }
+};

--- a/libs/common-ui/src/components/molecules/TaskDescription.tsx
+++ b/libs/common-ui/src/components/molecules/TaskDescription.tsx
@@ -8,12 +8,36 @@ import DOMPurify from "dompurify";
  * Uses DOMPurify with a safe default config.
  */
 const sanitize = (html: string): string => {
-  if (typeof window === "undefined") return html;
+  if (globalThis.window === undefined) return html;
   return DOMPurify.sanitize(html, {
     ALLOWED_TAGS: [
-      "b", "i", "em", "strong", "a", "p", "br", "ul", "ol", "li",
-      "code", "pre", "span", "div", "h1", "h2", "h3", "h4", "h5", "h6",
-      "blockquote", "table", "thead", "tbody", "tr", "th", "td",
+      "b",
+      "i",
+      "em",
+      "strong",
+      "a",
+      "p",
+      "br",
+      "ul",
+      "ol",
+      "li",
+      "code",
+      "pre",
+      "span",
+      "div",
+      "h1",
+      "h2",
+      "h3",
+      "h4",
+      "h5",
+      "h6",
+      "blockquote",
+      "table",
+      "thead",
+      "tbody",
+      "tr",
+      "th",
+      "td",
     ],
     ALLOWED_ATTR: ["href", "target", "rel", "class", "style"],
   });

--- a/specs/008-security-fixes-plan/tasks.md
+++ b/specs/008-security-fixes-plan/tasks.md
@@ -48,8 +48,8 @@
 
 ## Phase 8: PR06 - Sonar Complexity UI Components
 
-- [ ] T026 [P] [US6] Refactor NavbarSimple.tsx, EnhancedDashboard.tsx, ProblemSolvingEditorComponents.tsx, FrontendTaskEditorComponents.tsx, admin-learning-cards/editors/
-- [ ] T027 [US6] Extract nav sections and editor rendering into helpers/sub-components
+- [x] T026 [P] [US6] Refactor NavbarSimple.tsx, EnhancedDashboard.tsx, ProblemSolvingEditorComponents.tsx, FrontendTaskEditorComponents.tsx, admin-learning-cards/editors/
+- [x] T027 [US6] Extract nav sections and editor rendering into helpers/sub-components
 - [ ] T028 [US6] Commit fixes with message in contracts/PR06-sonar-complexity-ui-components.md
 
 ## Phase 9: PR07 - Sonar Complexity Utils


### PR DESCRIPTION
## Summary
- extract duplicated file-tree/editor utility helpers into a shared module
- re-export shared helpers to preserve existing public API usage
- harden `cleanReactCode` path by removing risky broad regex usage
- add repository-level `.coderabbit.yaml` for consistent low-noise PR reviews
- update security-fixes task checklist progress for completed UI-complexity sub-tasks

## Validation
- no compile errors reported in edited files
- Sonar potential security issues for edited editor files reduced to 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added project configuration (.coderabbit) for review and automation settings

* **Refactor**
  * Consolidated editor file handling into a shared utilities module to reduce duplication and reorganized editor exports

* **Bug Fixes**
  * Fixed console capture generation and improved sanitization environment detection in task descriptions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->