### PR TITLE
chore: reconcile stale bugs issues batch 5 (#11277-#11282)

### DIFF
--- a/docs/security/BUG_ISSUES_RECONCILIATION_2026-02-20_BATCH5.md
+++ b/docs/security/BUG_ISSUES_RECONCILIATION_2026-02-20_BATCH5.md
@@ -1,0 +1,33 @@
+# Bugs Issues Reconciliation — 2026-02-20 (Batch 5)
+
+## Scope
+
+Reconcile stale `bugs` issues that point to generated scan artifact paths no longer present in the repository.
+
+## Findings
+
+The following open `bugs` issues reference `gitleaks-current.json` while the file is missing in the current repository tree:
+
+- #11282 — Alert #2678
+- #11281 — Alert #2679
+- #11280 — Alert #2680
+- #11279 — Alert #2681
+- #11278 — Alert #2682
+- #11277 — Alert #2683
+
+## Verification
+
+- Checked each issue body and confirmed references to `gitleaks-current.json`
+- Verified local repository state: `gitleaks-current.json` is missing
+- Classified these as stale-path backlog issues for reconciliation closure
+
+## Action
+
+Close through PR-linked issue closure:
+
+- Closes #11282
+- Closes #11281
+- Closes #11280
+- Closes #11279
+- Closes #11278
+- Closes #11277


### PR DESCRIPTION
## Summary
- reconcile stale bugs issues that reference missing generated scan artifact path
- add audit note in docs/security/BUG_ISSUES_RECONCILIATION_2026-02-20_BATCH5.md

## Related
Closes #11282
Closes #11281
Closes #11280
Closes #11279
Closes #11278
Closes #11277

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for bug issue reconciliation process, addressing stale issues requiring closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->