### PR TITLE
chore: reconcile stale bugs issues batch 8 (#10889-#10894)

### DIFF
--- a/docs/security/BUG_ISSUES_RECONCILIATION_2026-02-20_BATCH8.md
+++ b/docs/security/BUG_ISSUES_RECONCILIATION_2026-02-20_BATCH8.md
@@ -1,0 +1,33 @@
+# Bugs Issues Reconciliation — 2026-02-20 (Batch 8)
+
+## Scope
+
+Reconcile stale `bugs` issues that reference generated scan artifact paths no longer present in the repository.
+
+## Findings
+
+The following open `bugs` issues reference `gitleaks-current.json`, while the file is missing in the current repository tree:
+
+- #10894 — Alert #3066
+- #10893 — Alert #3067
+- #10892 — Alert #3068
+- #10891 — Alert #3069
+- #10890 — Alert #3070
+- #10889 — Alert #3071
+
+## Verification
+
+- Checked issue bodies and confirmed all six reference `gitleaks-current.json`
+- Verified local repository state: `gitleaks-current.json` is missing
+- Classified as stale-path backlog issues for reconciliation closure
+
+## Action
+
+Close through PR-linked issue closure:
+
+- Closes #10894
+- Closes #10893
+- Closes #10892
+- Closes #10891
+- Closes #10890
+- Closes #10889


### PR DESCRIPTION
## Summary
- reconcile stale bugs issues that reference missing generated scan artifact path
- add audit note in docs/security/BUG_ISSUES_RECONCILIATION_2026-02-20_BATCH8.md

## Related
Closes #10894
Closes #10893
Closes #10892
Closes #10891
Closes #10890
Closes #10889

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added bug reconciliation documentation for stale issues identified in Batch 8 (2026-02-20), detailing findings and closure actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->