### PR TITLE
chore: reconcile stale bugs issues batch 11 (#10474-#10479)

### DIFF
--- a/docs/security/BUG_ISSUES_RECONCILIATION_2026-02-20_BATCH11.md
+++ b/docs/security/BUG_ISSUES_RECONCILIATION_2026-02-20_BATCH11.md
@@ -1,0 +1,33 @@
+# Bugs Issues Reconciliation — 2026-02-20 (Batch 11)
+
+## Scope
+
+Reconcile stale `bugs` issues that reference generated scan artifact paths no longer present in the repository.
+
+## Findings
+
+The following open `bugs` issues reference `gitleaks-history.json`, while the file is missing in the current repository tree:
+
+- #10479 — Alert #3481
+- #10478 — Alert #3482
+- #10477 — Alert #3483
+- #10476 — Alert #3484
+- #10475 — Alert #3485
+- #10474 — Alert #3486
+
+## Verification
+
+- Checked issue bodies and confirmed all six reference `gitleaks-history.json`
+- Verified local repository state: `gitleaks-history.json` is missing
+- Classified as stale-path backlog issues for reconciliation closure
+
+## Action
+
+Close through PR-linked issue closure:
+
+- Closes #10479
+- Closes #10478
+- Closes #10477
+- Closes #10476
+- Closes #10475
+- Closes #10474


### PR DESCRIPTION
## Summary
- reconcile stale bugs issues that reference missing generated scan artifact path
- add audit note in docs/security/BUG_ISSUES_RECONCILIATION_2026-02-20_BATCH11.md

## Related
Closes #10479
Closes #10478
Closes #10477
Closes #10476
Closes #10475
Closes #10474

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added reconciliation documentation summarizing the resolution and closure of six stale issues related to missing artifact paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->