### PR TITLE
chore: disable Code Scanning to Issues workflow

### DIFF
--- a/.github/workflows/code-scanning-to-issues.yml.disabled
+++ b/.github/workflows/code-scanning-to-issues.yml.disabled
@@ -68,3 +68,4 @@ jobs:
             tools/code-scanning-to-issues/*.log
           retention-days: 7
           if-no-files-found: ignore
+


### PR DESCRIPTION
Temporarily disable the code-scanning-to-issues workflow by renaming the workflow file to .disabled. Keeps the workflow content for easy re-enable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->