### PR TITLE
Hotfix: Resolve Vercel Infinite Loop v2

### DIFF
--- a/apps/website/next.config.ts
+++ b/apps/website/next.config.ts
@@ -93,14 +93,9 @@ const nextConfig: NextConfig = {
   // Disable automatic error page generation
   distDir: ".next",
 
-  // Replace redirects with rewrites for /admin to avoid loops on Vercel
+  // Rewrites are now primarily handled by middleware to prevent loop recursion
   async rewrites() {
-    return [
-      {
-        source: "/admin/:path*",
-        destination: `${process.env.ADMIN_URL || "http://localhost:3001"}/admin/:path*`,
-      },
-    ];
+    return [];
   },
 
   // Disable automatic error page generation


### PR DESCRIPTION
This PR fixes the 508 INFINITE_LOOP issue on Vercel by moving the /admin proxying to Middleware with a loop-detection header (x-elzatona-proxied).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin access is more reliable: proxy handling now prevents infinite proxy loops and falls back safely if proxying fails.
* **Chores**
  * Admin routing rewrites moved from config to runtime handling, simplifying route behavior and avoiding rewrite recursion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->