### PR TITLE
Hotfix: Resolve Admin 404 (Missing Host Header)

### DIFF
--- a/apps/website/middleware.ts
+++ b/apps/website/middleware.ts
@@ -17,9 +17,17 @@ export function middleware(request: NextRequest): NextResponse | Response {
       // Prepare the proxy URL
       const url = new URL(pathname + search, adminUrl);
 
-      // Prepare headers for propagation (CodeRabbit logic: send to downstream)
+      // Prepare headers for propagation
       const requestHeaders = new Headers(request.headers);
       requestHeaders.set("x-elzatona-proxied", "true");
+
+      // CRITICAL: Set Host header to the target host for Vercel routing
+      // Without this, the target project will receive the "elzatona-web.com" host
+      // and reject the request with a 404.
+      requestHeaders.set("host", url.host);
+
+      // Remove headers that might cause the target to reject the request
+      requestHeaders.delete("x-forwarded-host");
 
       // Create the rewrite response with propagated headers
       return NextResponse.rewrite(url, {


### PR DESCRIPTION
This follow-up PR adds the critical 'Host' header rewrite to the /admin proxy middleware, which was missed in the previous merge #12011. This fix is required to resolve the 404 on elzatona-web.com/admin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the admin proxy path was not correctly forwarding requests to the target server due to improper header handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->