### PR TITLE
Debug: Admin 404 Middleware Headers

### DIFF
--- a/apps/website/middleware.ts
+++ b/apps/website/middleware.ts
@@ -37,8 +37,11 @@ export function middleware(request: NextRequest): NextResponse | Response {
       });
     } catch (error) {
       console.error("Middleware rewrite error:", error);
-      // Fallback: if proxying fails, let the request proceed to avoid crashing the site
-      return NextResponse.next();
+      const fallback = NextResponse.next();
+      fallback.headers.set("x-mw-debug-error", String(error));
+      fallback.headers.set("x-mw-debug-admin-url", adminUrl || "not-set");
+      fallback.headers.set("x-mw-debug-pathname", pathname);
+      return fallback;
     }
   }
 


### PR DESCRIPTION
This PR adds temporary debug headers to the middleware to identify why the /admin proxy is failing. Check response headers: x-mw-debug-error, x-mw-debug-admin-url, x-mw-debug-pathname.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced middleware error handling with additional diagnostic headers to support troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->