### PR TITLE
Debug: Global Middleware Headers

### DIFF
--- a/apps/website/middleware.ts
+++ b/apps/website/middleware.ts
@@ -92,6 +92,16 @@ export function middleware(request: NextRequest): NextResponse | Response {
     "geolocation=(), microphone=(), camera=()",
   );
 
+  response.headers.set("x-mw-debug-pathname", pathname);
+  response.headers.set(
+    "x-mw-debug-host",
+    request.headers.get("host") || "not-set",
+  );
+  response.headers.set(
+    "x-mw-debug-admin-url",
+    process.env.ADMIN_URL || "not-set",
+  );
+
   return response;
 }
 


### PR DESCRIPTION
Adding headers to EVERY response to see what the middleware sees. Check: x-mw-debug-pathname, x-mw-debug-host, x-mw-debug-admin-url.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal infrastructure improvements for debugging and monitoring purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->