### PR TITLE
fix(admin-auth): use service role for admin lookup to bypass RLS

### DIFF
--- a/libs/database/src/adapters/postgresql/PostgreSQLUserRepository.ts
+++ b/libs/database/src/adapters/postgresql/PostgreSQLUserRepository.ts
@@ -87,7 +87,7 @@ export class PostgreSQLUserRepository
 
   async findAdminByEmail(email: string): Promise<User | null> {
     try {
-      const { data, error } = await this.client
+      const { data, error } = await this.getClient(true)
         .from("admin_users")
         .select("*")
         .eq("email", email)


### PR DESCRIPTION
This PR is a follow-up to PR #12024. It ensures the Admin Auth API uses the  client for user lookup, which is necessary to bypass RLS on the  table in production. This finally resolves the 'No admin found' (401) error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal database connection handling for admin user retrieval operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->