### PR TITLE
fix(admin): set assetPrefix for multi-zone deployment at /admin

### DIFF
--- a/apps/admin/next.config.js
+++ b/apps/admin/next.config.js
@@ -21,6 +21,24 @@ const nextConfig = {
     // Use a static build ID to ensure consistent builds
     return "admin-build";
   },
+
+  // Multi-zone: the admin app is served at /admin on elzatona-web.com.
+  // Setting assetPrefix ensures the HTML it produces references
+  // /admin/_next/static/… instead of /_next/static/…, so Vercel's
+  // path-based routing sends those asset requests to THIS deployment
+  // rather than the main website deployment.
+  assetPrefix: process.env.NODE_ENV === "production" ? "/admin" : "",
+
+  async rewrites() {
+    // Allow the admin deployment itself to serve the /admin/_next/* paths
+    // that the browser requests due to the assetPrefix above.
+    return [
+      {
+        source: "/admin/_next/:path*",
+        destination: "/_next/:path*",
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
When the admin Vercel project is served at elzatona-web.com/admin via Vercel's path-based multi-zone routing, the admin HTML (without assetPrefix) references /_next/static/chunks/* assets. Those requests are routed by Vercel to the website deployment instead of the admin deployment, which causes all JS/CSS to 404 (white screen).

Fix:
- assetPrefix: '/admin' (production only) — makes the HTML emit /admin/_next/static/… URLs which Vercel routes to THIS deployment.
- rewrites: /admin/_next/:path* → /_next/:path* — so the admin server can serve its own static assets from the /admin/_next/ prefix path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated admin panel deployment configuration to ensure static assets are correctly served in production environments when deployed with path-based routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->