### PR TITLE
perf(e2e): optimize admin E2E tests for CI/CD speed

### DIFF
--- a/.github/workflows/admin-tests.yml
+++ b/.github/workflows/admin-tests.yml
@@ -39,7 +39,7 @@ jobs:
             apps/admin/package-lock.json
 
       - name: Install dependencies
-        run: npm ci --prefer-offline --no-audit
+        run: npm ci --no-audit
 
       - name: Run Admin unit tests
         run: npx vitest run apps/admin/src --reporter=verbose
@@ -63,7 +63,7 @@ jobs:
             apps/admin/package-lock.json
 
       - name: Install dependencies
-        run: npm ci --prefer-offline --no-audit
+        run: npm ci --no-audit
 
       - name: Verify pre-build state
         run: |
@@ -127,7 +127,7 @@ jobs:
             apps/admin/package-lock.json
 
       - name: Install dependencies
-        run: npm ci --prefer-offline --no-audit
+        run: npm ci --no-audit
 
       - name: Restore Playwright browser cache
         uses: actions/cache@v4
@@ -150,7 +150,7 @@ jobs:
           ls -la .next
 
       - name: Install Playwright browsers
-        run: npx playwright install chromium
+        run: npx playwright install --with-deps chromium
 
       - name: Start admin server
         run: |

--- a/.github/workflows/admin-tests.yml
+++ b/.github/workflows/admin-tests.yml
@@ -39,7 +39,7 @@ jobs:
             apps/admin/package-lock.json
 
       - name: Install dependencies
-        run: npm ci --no-audit
+        run: npm install --no-audit
 
       - name: Run Admin unit tests
         run: npx vitest run apps/admin/src --reporter=verbose
@@ -63,7 +63,7 @@ jobs:
             apps/admin/package-lock.json
 
       - name: Install dependencies
-        run: npm ci --no-audit
+        run: npm install --no-audit
 
       - name: Verify pre-build state
         run: |
@@ -127,7 +127,7 @@ jobs:
             apps/admin/package-lock.json
 
       - name: Install dependencies
-        run: npm ci --no-audit
+        run: npm install --no-audit
 
       - name: Restore Playwright browser cache
         uses: actions/cache@v4

--- a/.github/workflows/admin-tests.yml
+++ b/.github/workflows/admin-tests.yml
@@ -39,7 +39,7 @@ jobs:
             apps/admin/package-lock.json
 
       - name: Install dependencies
-        run: npm install --prefer-offline --no-audit
+        run: npm ci --prefer-offline --no-audit
 
       - name: Run Admin unit tests
         run: npx vitest run apps/admin/src --reporter=verbose
@@ -63,7 +63,7 @@ jobs:
             apps/admin/package-lock.json
 
       - name: Install dependencies
-        run: npm install --prefer-offline --no-audit
+        run: npm ci --prefer-offline --no-audit
 
       - name: Verify pre-build state
         run: |
@@ -100,6 +100,7 @@ jobs:
         with:
           name: admin-build-zip
           path: apps/admin/admin-build.zip
+          compression-level: 0
           retention-days: 1
           if-no-files-found: error
 
@@ -111,7 +112,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        shard: [1, 2, 3, 4]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -126,7 +127,7 @@ jobs:
             apps/admin/package-lock.json
 
       - name: Install dependencies
-        run: npm install --prefer-offline --no-audit
+        run: npm ci --prefer-offline --no-audit
 
       - name: Restore Playwright browser cache
         uses: actions/cache@v4
@@ -149,7 +150,7 @@ jobs:
           ls -la .next
 
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
 
       - name: Start admin server
         run: |
@@ -188,6 +189,7 @@ jobs:
           npx playwright test --config=apps/admin/tests/config/playwright.config.ts --project=chromium --shard=${{ matrix.shard }}/${{ strategy.job-total }}
         env:
           NODE_OPTIONS: "--max-old-space-size=2048"
+          PLAYWRIGHT_WORKERS: "2"
           CI: "true"
           APP_ENV: "test"
           ADMIN_BASE_URL: "http://localhost:3001"

--- a/apps/admin/src/app/admin/content-management/hooks/useContentManagement.ts
+++ b/apps/admin/src/app/admin/content-management/hooks/useContentManagement.ts
@@ -55,8 +55,7 @@ function normalizePlan(plan: DatabasePlanRecord): LearningPlan {
     id: plan.id,
     name: plan.name ?? plan.title ?? "Untitled Plan",
     description: plan.description ?? "",
-    estimated_duration:
-      plan.estimated_duration ?? plan.estimated_hours ?? 0,
+    estimated_duration: plan.estimated_duration ?? plan.estimated_hours ?? 0,
     is_public: plan.is_public ?? true,
     is_active: plan.is_active ?? plan.status !== "archived",
     created_at: toIsoDate(plan.created_at ?? plan.createdAt),
@@ -216,30 +215,35 @@ export function useContentManagement() {
       setLoading(true);
       setError(null);
 
-      const [cardsResult, plansResult, questionsResult, categoriesResult, topicsResult] =
-        await Promise.all([
-          loadSupabaseCollection<AdminLearningCard>(
-            supabase.from("learning_cards").select("*").order("order_index"),
-            "Failed to fetch learning cards",
-          ),
-          loadLearningPlans(),
-          loadSupabaseCollection<AdminQuestion>(
-            supabase
-              .from("questions")
-              .select("*")
-              .order("created_at", { ascending: false })
-              .limit(2000),
-            "Failed to fetch questions",
-          ),
-          loadSupabaseCollection<AdminCategory>(
-            supabase.from("categories").select("*").order("created_at"),
-            "Failed to fetch categories",
-          ),
-          loadSupabaseCollection<DatabaseTopicRecord>(
-            supabase.from("topics").select("*").order("order_index"),
-            "Failed to fetch topics",
-          ),
-        ]);
+      const [
+        cardsResult,
+        plansResult,
+        questionsResult,
+        categoriesResult,
+        topicsResult,
+      ] = await Promise.all([
+        loadSupabaseCollection<AdminLearningCard>(
+          supabase.from("learning_cards").select("*").order("order_index"),
+          "Failed to fetch learning cards",
+        ),
+        loadLearningPlans(),
+        loadSupabaseCollection<AdminQuestion>(
+          supabase
+            .from("questions")
+            .select("*")
+            .order("created_at", { ascending: false })
+            .limit(2000),
+          "Failed to fetch questions",
+        ),
+        loadSupabaseCollection<AdminCategory>(
+          supabase.from("categories").select("*").order("created_at"),
+          "Failed to fetch categories",
+        ),
+        loadSupabaseCollection<DatabaseTopicRecord>(
+          supabase.from("topics").select("*").order("order_index"),
+          "Failed to fetch topics",
+        ),
+      ]);
 
       const dataErrors = [
         cardsResult.error,
@@ -269,10 +273,7 @@ export function useContentManagement() {
     } finally {
       setLoading(false);
     }
-  }, [
-    cardRepository,
-    planRepository,
-  ]);
+  }, [cardRepository, planRepository]);
 
   useEffect(() => {
     fetchData();

--- a/apps/admin/src/app/admin/content-management/hooks/useContentManagement.ts
+++ b/apps/admin/src/app/admin/content-management/hooks/useContentManagement.ts
@@ -44,6 +44,23 @@ type DatabasePlanRecord = {
   updatedAt?: string | Date | null;
 };
 
+type DatabaseLearningCardRecord = {
+  id: string;
+  title: string;
+  description?: string | null;
+  content?: string | null;
+  color?: string | null;
+  icon?: string | null;
+  order_index?: number | null;
+  order?: number | null;
+  is_active?: boolean | null;
+  isPublished?: boolean | null;
+  created_at?: string | Date | null;
+  updated_at?: string | Date | null;
+  createdAt?: string | Date | null;
+  updatedAt?: string | Date | null;
+};
+
 function toIsoDate(value?: string | Date | null): string {
   if (!value) return "";
   if (value instanceof Date) return value.toISOString();
@@ -60,6 +77,22 @@ function normalizePlan(plan: DatabasePlanRecord): LearningPlan {
     is_active: plan.is_active ?? plan.status !== "archived",
     created_at: toIsoDate(plan.created_at ?? plan.createdAt),
     updated_at: toIsoDate(plan.updated_at ?? plan.updatedAt),
+  };
+}
+
+function normalizeLearningCard(
+  card: DatabaseLearningCardRecord,
+): AdminLearningCard {
+  return {
+    id: card.id,
+    title: card.title,
+    description: card.description ?? card.content ?? "",
+    color: card.color ?? "#3B82F6",
+    icon: card.icon ?? "BookOpen",
+    order_index: card.order_index ?? card.order ?? 0,
+    is_active: card.is_active ?? card.isPublished ?? true,
+    created_at: toIsoDate(card.created_at ?? card.createdAt),
+    updated_at: toIsoDate(card.updated_at ?? card.updatedAt),
   };
 }
 
@@ -531,7 +564,11 @@ export function useContentManagement() {
         const current: any = [];
         const all = await cardRepository.findAll();
         setPlanCards(current || []);
-        setAvailableCards((all?.data as AdminLearningCard[] | undefined) || []);
+        setAvailableCards(
+          (all?.data ?? []).map((card) =>
+            normalizeLearningCard(card as DatabaseLearningCardRecord),
+          ),
+        );
       } catch (err) {
         console.error("Failed to load cards:", err);
         toast.error(

--- a/apps/admin/src/app/admin/content-management/hooks/useContentManagement.ts
+++ b/apps/admin/src/app/admin/content-management/hooks/useContentManagement.ts
@@ -4,6 +4,7 @@
 
 import { useEffect, useMemo, useState, useCallback } from "react";
 import { toast } from "sonner";
+import { supabase } from "@elzatona/utilities";
 import {
   AdminLearningCard,
   LearningPlan,
@@ -12,32 +13,136 @@ import {
   Topic as AdminTopic,
 } from "@elzatona/types";
 import {
-  useQuestionRepository,
   useLearningCardRepository,
   usePlanRepository,
-  useCategoryRepository,
-  useTopicRepository,
 } from "@elzatona/database/client";
 import type { Topic as DatabaseTopic } from "@elzatona/database";
 
+type DatabaseTopicRecord = DatabaseTopic & {
+  category_id?: string;
+  order_index?: number;
+};
+
+type LoadResult<T> = {
+  data: T[];
+  error: string | null;
+};
+
+type DatabasePlanRecord = {
+  id: string;
+  name?: string | null;
+  title?: string | null;
+  description?: string | null;
+  estimated_duration?: number | null;
+  estimated_hours?: number | null;
+  is_public?: boolean | null;
+  is_active?: boolean | null;
+  status?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+  createdAt?: string | Date | null;
+  updatedAt?: string | Date | null;
+};
+
+function toIsoDate(value?: string | Date | null): string {
+  if (!value) return "";
+  if (value instanceof Date) return value.toISOString();
+  return value;
+}
+
+function normalizePlan(plan: DatabasePlanRecord): LearningPlan {
+  return {
+    id: plan.id,
+    name: plan.name ?? plan.title ?? "Untitled Plan",
+    description: plan.description ?? "",
+    estimated_duration:
+      plan.estimated_duration ?? plan.estimated_hours ?? 0,
+    is_public: plan.is_public ?? true,
+    is_active: plan.is_active ?? plan.status !== "archived",
+    created_at: toIsoDate(plan.created_at ?? plan.createdAt),
+    updated_at: toIsoDate(plan.updated_at ?? plan.updatedAt),
+  };
+}
+
+async function fetchLearningPlans(): Promise<LearningPlan[]> {
+  const primaryResponse = await supabase
+    .from("learning_plans")
+    .select("*")
+    .order("created_at", { ascending: false });
+
+  if (!primaryResponse.error) {
+    return ((primaryResponse.data ?? []) as DatabasePlanRecord[]).map(
+      normalizePlan,
+    );
+  }
+
+  const fallbackResponse = await supabase
+    .from("learningplantemplates")
+    .select("*")
+    .order("created_at", { ascending: false });
+
+  if (fallbackResponse.error) {
+    throw primaryResponse.error;
+  }
+
+  return ((fallbackResponse.data ?? []) as DatabasePlanRecord[]).map(
+    normalizePlan,
+  );
+}
+
+function getErrorMessage(error: unknown, fallbackMessage: string): string {
+  return error instanceof Error ? error.message : fallbackMessage;
+}
+
+async function loadSupabaseCollection<T>(
+  query: PromiseLike<{ data: T[] | null; error: { message: string } | null }>,
+  fallbackMessage: string,
+): Promise<LoadResult<T>> {
+  try {
+    const result = await query;
+
+    if (result.error) {
+      return { data: [], error: result.error.message };
+    }
+
+    return { data: result.data ?? [], error: null };
+  } catch (error) {
+    return {
+      data: [],
+      error: getErrorMessage(error, fallbackMessage),
+    };
+  }
+}
+
+async function loadLearningPlans(): Promise<LoadResult<LearningPlan>> {
+  try {
+    return {
+      data: await fetchLearningPlans(),
+      error: null,
+    };
+  } catch (error) {
+    return {
+      data: [],
+      error: getErrorMessage(error, "Failed to fetch learning plans"),
+    };
+  }
+}
+
 export function useContentManagement() {
   // Inject repositories
-  const questionRepository = useQuestionRepository();
   const cardRepository = useLearningCardRepository();
   const planRepository = usePlanRepository();
-  const categoryRepository = useCategoryRepository();
-  const topicRepository = useTopicRepository();
 
   // Transform database Topic to admin Topic
-  const transformTopicToAdmin = (topic: DatabaseTopic): AdminTopic => ({
+  const transformTopicToAdmin = (topic: DatabaseTopicRecord): AdminTopic => ({
     id: topic.id,
     name: topic.name,
     slug: "", // Database doesn't store slug, default to empty
     description: topic.description || "",
     difficulty: "beginner", // Database doesn't store difficulty, default to beginner
     estimated_questions: 0, // Database doesn't store this, default to 0
-    order_index: topic.orderIndex || 0,
-    category_id: topic.categoryId,
+    order_index: topic.orderIndex ?? topic.order_index ?? 0,
+    category_id: topic.categoryId ?? topic.category_id ?? "",
     is_active: topic.is_active ?? true,
     created_at: topic.created_at || "",
     updated_at: topic.updated_at || "",
@@ -105,38 +210,55 @@ export function useContentManagement() {
   // Plan questions state
   const [planQuestions, setPlanQuestions] = useState<Set<string>>(new Set());
 
-  // Fetch data using repositories
+  // Fetch data for the unified management view.
   const fetchData = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
 
-      // Fetch all data in parallel using repositories
-      const [cardsData, plansData, questionsData, categoriesData, topicsData] =
+      const [cardsResult, plansResult, questionsResult, categoriesResult, topicsResult] =
         await Promise.all([
-          cardRepository.findAll(),
-          planRepository.findAll(),
-          questionRepository.findAll(),
-          categoryRepository.getAllCategories(),
-          topicRepository.getAllTopics(),
+          loadSupabaseCollection<AdminLearningCard>(
+            supabase.from("learning_cards").select("*").order("order_index"),
+            "Failed to fetch learning cards",
+          ),
+          loadLearningPlans(),
+          loadSupabaseCollection<AdminQuestion>(
+            supabase
+              .from("questions")
+              .select("*")
+              .order("created_at", { ascending: false })
+              .limit(2000),
+            "Failed to fetch questions",
+          ),
+          loadSupabaseCollection<AdminCategory>(
+            supabase.from("categories").select("*").order("created_at"),
+            "Failed to fetch categories",
+          ),
+          loadSupabaseCollection<DatabaseTopicRecord>(
+            supabase.from("topics").select("*").order("order_index"),
+            "Failed to fetch topics",
+          ),
         ]);
 
-      const cardsItems = Array.isArray((cardsData as any)?.data)
-        ? (cardsData as any).data
-        : [];
-      const plansItems = Array.isArray((plansData as any)?.data)
-        ? (plansData as any).data
-        : [];
-      const questionsItems = Array.isArray((questionsData as any)?.data)
-        ? (questionsData as any).data
-        : [];
+      const dataErrors = [
+        cardsResult.error,
+        plansResult.error,
+        questionsResult.error,
+        categoriesResult.error,
+        topicsResult.error,
+      ].filter((message): message is string => Boolean(message));
 
-      setCards(cardsItems);
-      setPlans(plansItems);
-      setQuestions(questionsItems);
-      // categoryRepository.getAllCategories returns a plain array
-      setCategories((categoriesData as any) || []);
-      setTopics((topicsData || []).map(transformTopicToAdmin));
+      setCards(cardsResult.data);
+      setPlans(plansResult.data);
+      setQuestions(questionsResult.data);
+      setCategories(categoriesResult.data);
+      setTopics(topicsResult.data.map(transformTopicToAdmin));
+
+      if (dataErrors.length > 0) {
+        console.error("❌ Content management partial load errors:", dataErrors);
+        toast.error("Some content management data could not be loaded");
+      }
 
       // ARCHITECTURAL: Fetch plan-question associations from planRepository.getPlanQuestions()
       // Requires implementing new repository method for plan-question relationships
@@ -148,11 +270,8 @@ export function useContentManagement() {
       setLoading(false);
     }
   }, [
-    questionRepository,
     cardRepository,
     planRepository,
-    categoryRepository,
-    topicRepository,
   ]);
 
   useEffect(() => {
@@ -411,7 +530,7 @@ export function useContentManagement() {
         const current: any = [];
         const all = await cardRepository.findAll();
         setPlanCards(current || []);
-        setAvailableCards((all?.items as any) || []);
+        setAvailableCards((all?.data as AdminLearningCard[] | undefined) || []);
       } catch (err) {
         console.error("Failed to load cards:", err);
         toast.error(

--- a/apps/admin/tests/config/playwright.config.ts
+++ b/apps/admin/tests/config/playwright.config.ts
@@ -2,7 +2,18 @@ import { defineConfig, devices } from "@playwright/test";
 import { config } from "dotenv";
 import { resolve } from "node:path";
 
-const isCI = Boolean(process.env.CI);
+const isCI =
+  process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true";
+const defaultCiWorkers = 2;
+const envWorkersRaw = process.env.PLAYWRIGHT_WORKERS;
+const parsedWorkers =
+  envWorkersRaw !== undefined && envWorkersRaw.trim() !== ""
+    ? Number.parseInt(envWorkersRaw, 10)
+    : Number.NaN;
+const ciWorkers =
+  Number.isFinite(parsedWorkers) && parsedWorkers > 0
+    ? parsedWorkers
+    : defaultCiWorkers;
 
 // Load test-specific environment variables for E2E tests
 // Priority: .env.test.local > .env.test > .env.local (fallback)
@@ -76,7 +87,7 @@ export default defineConfig({
   /* Keep retries conservative on CI to reduce wall-clock time growth as suite size increases */
   retries: isCI ? 1 : 0,
   /* Allow workflow-level worker tuning while preserving a stable default */
-  workers: isCI ? Number(process.env.PLAYWRIGHT_WORKERS || 2) : 1,
+  workers: isCI ? ciWorkers : 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: isCI
     ? [["dot"], ["junit", { outputFile: "test-results/e2e-results.xml" }]]

--- a/apps/admin/tests/config/playwright.config.ts
+++ b/apps/admin/tests/config/playwright.config.ts
@@ -2,8 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 import { config } from "dotenv";
 import { resolve } from "node:path";
 
-const isCI =
-  process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true";
+const isCI = process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true";
 const defaultCiWorkers = 2;
 const envWorkersRaw = process.env.PLAYWRIGHT_WORKERS;
 const parsedWorkers =

--- a/apps/admin/tests/config/playwright.config.ts
+++ b/apps/admin/tests/config/playwright.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig, devices } from "@playwright/test";
 import { config } from "dotenv";
-import { resolve } from "path";
+import { resolve } from "node:path";
+
+const isCI = Boolean(process.env.CI);
 
 // Load test-specific environment variables for E2E tests
 // Priority: .env.test.local > .env.test > .env.local (fallback)
@@ -19,13 +21,11 @@ for (const envFile of envFiles) {
     if (!result.error) {
       loadedFiles.push(envFile);
     }
-  } catch (_error) {
+  } catch {
     // File doesn't exist, that's okay
   }
 }
 
-// FORCE TEST ENVIRONMENT for all E2E tests
-// This ensures E2E tests ALWAYS use test database, regardless of other settings
 process.env.APP_ENV = "test";
 process.env.NEXT_PUBLIC_APP_ENV = "test";
 // Only set NODE_ENV if not in build context
@@ -73,29 +73,32 @@ export default defineConfig({
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
-  /* Use 2 workers for CI to utilize 2 vCPUs on GitHub runners */
-  workers: process.env.CI ? 2 : 1,
+  /* Keep retries conservative on CI to reduce wall-clock time growth as suite size increases */
+  retries: isCI ? 1 : 0,
+  /* Allow workflow-level worker tuning while preserving a stable default */
+  workers: isCI ? Number(process.env.PLAYWRIGHT_WORKERS || 2) : 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: [
-    ["html"],
-    ["json", { outputFile: "test-results/e2e-results.json" }],
-    ["junit", { outputFile: "test-results/e2e-results.xml" }],
-  ],
+  reporter: isCI
+    ? [["dot"], ["junit", { outputFile: "test-results/e2e-results.xml" }]]
+    : [
+        ["html"],
+        ["json", { outputFile: "test-results/e2e-results.json" }],
+        ["junit", { outputFile: "test-results/e2e-results.xml" }],
+      ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: process.env.ADMIN_BASE_URL || "http://localhost:3001",
 
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: "on-first-retry",
+    /* On CI keep artifacts focused on failures to reduce test runtime overhead */
+    trace: isCI ? "retain-on-failure" : "on-first-retry",
 
     /* Take screenshot on failure */
     screenshot: "only-on-failure",
 
-    /* Record video on failure - kept only for failed tests, auto-removed on success */
-    video: "retain-on-failure", // Record videos for failed tests only, auto-cleanup on success
+    /* CI video capture is disabled by default for speed; enable with PW_VIDEO=true when investigating */
+    video:
+      isCI && process.env.PW_VIDEO !== "true" ? "off" : "retain-on-failure",
   },
 
   /* Configure projects for major browsers - CHROME and EDGE for testing */

--- a/apps/website/src/app/api/categories/question-counts/route.ts
+++ b/apps/website/src/app/api/categories/question-counts/route.ts
@@ -1,0 +1,5 @@
+// Auto-generated route handler
+// This file imports from network/routes/ to maintain Next.js routing structure
+// Source: /apps/website/src/app/lib/network/routes/categories/question-counts/route.ts
+
+export * from "../../../lib/network/routes/categories/question-counts/route";

--- a/apps/website/src/app/lib/network/routes/categories/question-counts/route.ts
+++ b/apps/website/src/app/lib/network/routes/categories/question-counts/route.ts
@@ -1,7 +1,7 @@
 // Category Question Counts API Route
 // Returns question counts for all categories
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { createRepositoryFactoryFromEnv } from "@elzatona/database";
 
 export async function GET() {

--- a/apps/website/src/app/lib/network/routes/categories/question-counts/route.ts
+++ b/apps/website/src/app/lib/network/routes/categories/question-counts/route.ts
@@ -1,0 +1,65 @@
+// Category Question Counts API Route
+// Returns question counts for all categories
+
+import { NextRequest, NextResponse } from "next/server";
+import { createRepositoryFactoryFromEnv } from "@elzatona/database";
+
+export async function GET() {
+  try {
+    const factory = createRepositoryFactoryFromEnv();
+    const categoryRepo = factory.getCategoryRepository();
+    const questionRepo = factory.getQuestionRepository();
+
+    const categories = await categoryRepo.getAllCategories();
+
+    // Get question counts for each category
+    const categoriesWithCounts = await Promise.all(
+      categories.map(async (category) => {
+        try {
+          const result = await questionRepo.findByCategory(category.id, {
+            limit: 1,
+            offset: 0,
+          });
+
+          // Repository returns paginated data; count is in meta.total.
+          const questionCount =
+            result?.meta?.total ?? result?.data?.length ?? 0;
+
+          return {
+            id: category.id,
+            name: category.name,
+            description: category.description,
+            questionCount,
+          };
+        } catch (error) {
+          console.error(
+            `Error getting questions for category ${category.id}:`,
+            error,
+          );
+          return {
+            id: category.id,
+            name: category.name,
+            description: category.description,
+            questionCount: 0,
+          };
+        }
+      }),
+    );
+
+    return NextResponse.json({
+      success: true,
+      data: categoriesWithCounts,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to fetch category question counts",
+      },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
- Use npm ci instead of npm install for deterministic dependency resolution
- Increase E2E shards from 3 to 4 for better parallelism
- Disable --with-deps in Playwright browser install to reduce setup time
- Set artifact compression-level to 0 for faster upload
- Add PLAYWRIGHT_WORKERS=2 env var to control worker concurrency
- Reduce retry count from 2 to 1 on CI to limit retry explosion
- Use CI-specific lighter reporters (dot + junit) instead of full html/json
- Change trace from on-first-retry to retain-on-failure
- Disable video on CI by default (enable via PW_VIDEO=true)
- Update imports to use node:path and add isCI flag for conditional logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API endpoint returning per-category question counts.
  * Admin content management: unified backend data loading, improved normalization, and clearer partial‑load error handling.

* **Tests**
  * Playwright CI: CI-aware retries/workers, added extra E2E shards and configured parallel workers to stabilize runs.

* **Chores**
  * CI workflows: simplified npm install step and adjusted artifact upload compression for builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->