### PR TITLE
fix(admin-content-management): restore hierarchy relations and wire CRUD actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -253,8 +253,6 @@ build/
 .github/workflows/codeql-config.yml
 # Utility scripts (development only)
 libs/utilities/scripts/
-tools/
-!tools/code-scanning-to-issues/
 tools/*/node_modules/
 apps/*/tests/e2e/
 .cursor/

--- a/apps/admin/src/app/admin/content-management/hooks/useContentManagement.ts
+++ b/apps/admin/src/app/admin/content-management/hooks/useContentManagement.ts
@@ -23,6 +23,10 @@ type DatabaseTopicRecord = DatabaseTopic & {
   order_index?: number;
 };
 
+type DatabaseCategoryRecord = AdminCategory & {
+  card_type?: string | null;
+};
+
 type LoadResult<T> = {
   data: T[];
   error: string | null;
@@ -80,6 +84,8 @@ type PlanQuestionInsertRow = {
   is_active: boolean;
 };
 
+type CanonicalCardKey = "core" | "framework" | "problem" | "system";
+
 const PLAN_DISTRIBUTION = [
   { newPerCard: 2, reviewPerCard: 0 },
   { newPerCard: 2, reviewPerCard: 1 },
@@ -87,13 +93,124 @@ const PLAN_DISTRIBUTION = [
   { newPerCard: 1, reviewPerCard: 3 },
 ] as const;
 
+const CANONICAL_CARDS: Array<{
+  key: CanonicalCardKey;
+  title: string;
+  description: string;
+  color: string;
+  icon: string;
+  order: number;
+}> = [
+  {
+    key: "core",
+    title: "Core Technologies",
+    description: "HTML, CSS, JavaScript, TypeScript",
+    color: "#3B82F6",
+    icon: "Layers",
+    order: 0,
+  },
+  {
+    key: "framework",
+    title: "Framework Questions",
+    description: "React, Next.js, Vue, Angular, Svelte",
+    color: "#10B981",
+    icon: "Layers",
+    order: 1,
+  },
+  {
+    key: "problem",
+    title: "Problem Solving",
+    description: "Frontend coding challenges and algorithms",
+    color: "#F59E0B",
+    icon: "Layers",
+    order: 2,
+  },
+  {
+    key: "system",
+    title: "System Design",
+    description: "Frontend architecture patterns",
+    color: "#EF4444",
+    icon: "Layers",
+    order: 3,
+  },
+];
+
+function inferCardKeyFromCategory(
+  category: DatabaseCategoryRecord,
+): CanonicalCardKey {
+  const hint =
+    `${category.card_type ?? ""} ${category.name ?? ""}`.toLowerCase();
+
+  if (
+    hint.includes("framework") ||
+    hint.includes("react") ||
+    hint.includes("next") ||
+    hint.includes("vue") ||
+    hint.includes("angular") ||
+    hint.includes("svelte")
+  ) {
+    return "framework";
+  }
+
+  if (
+    hint.includes("problem") ||
+    hint.includes("algorithm") ||
+    hint.includes("coding") ||
+    hint.includes("challenge")
+  ) {
+    return "problem";
+  }
+
+  if (
+    hint.includes("system") ||
+    hint.includes("architecture") ||
+    hint.includes("design")
+  ) {
+    return "system";
+  }
+
+  return "core";
+}
+
+function buildCanonicalCards(cards: AdminLearningCard[]): {
+  cards: AdminLearningCard[];
+  idsByKey: Record<CanonicalCardKey, string>;
+} {
+  const idsByKey = {
+    core: "",
+    framework: "",
+    problem: "",
+    system: "",
+  } as Record<CanonicalCardKey, string>;
+
+  const canonicalCards = CANONICAL_CARDS.map((meta) => {
+    const existing = cards.find((card) => card.title === meta.title);
+    const normalized: AdminLearningCard = existing ?? {
+      id: `virtual-${meta.key}`,
+      title: meta.title,
+      description: meta.description,
+      color: meta.color,
+      icon: meta.icon,
+      order_index: meta.order,
+      is_active: true,
+      created_at: "",
+      updated_at: "",
+    };
+
+    idsByKey[meta.key] = normalized.id;
+    return normalized;
+  });
+
+  return { cards: canonicalCards, idsByKey };
+}
+
 function generatePlanMetadata(sequence: number): PlanGenerationMetadata {
   switch (sequence) {
     case 1:
       return {
-        title: "Foundations",
+        title: "Initial",
         description:
-          "Day 1 kickoff with all cards available and 1-2 new questions per card.",
+          "Initial plan with new questions across all four learning cards.",
         plan_type: "initial",
         sequence_index: 1,
         new_question_count: 0,
@@ -101,8 +218,8 @@ function generatePlanMetadata(sequence: number): PlanGenerationMetadata {
       };
     case 2:
       return {
-        title: "Review & Deepen",
-        description: "Day 2 adds new questions and starts lightweight review.",
+        title: "Review",
+        description: "Review plan that mixes new and review questions.",
         plan_type: "reinforcement",
         sequence_index: 2,
         new_question_count: 0,
@@ -110,9 +227,9 @@ function generatePlanMetadata(sequence: number): PlanGenerationMetadata {
       };
     case 3:
       return {
-        title: "Advanced Mastery",
+        title: "Advanced",
         description:
-          "Day 3 emphasizes harder review while still introducing new items.",
+          "Advanced plan emphasizing harder review while introducing new items.",
         plan_type: "advanced",
         sequence_index: 3,
         new_question_count: 0,
@@ -120,9 +237,9 @@ function generatePlanMetadata(sequence: number): PlanGenerationMetadata {
       };
     default:
       return {
-        title: "Weekly Check-in",
+        title: "Maintenance",
         description:
-          "Maintenance day with mostly review and a small amount of new content.",
+          "Maintenance plan with mostly review and a small amount of new content.",
         plan_type: "maintenance",
         sequence_index: 4,
         new_question_count: 0,
@@ -142,6 +259,10 @@ function hasExistingSpacedPlans(plans: LearningPlan[]): boolean {
   const matches = plans.filter((plan) => {
     const lowered = `${plan.name} ${plan.description}`.toLowerCase();
     return (
+      lowered.includes("initial") ||
+      lowered.includes("review") ||
+      lowered.includes("advanced") ||
+      lowered.includes("maintenance") ||
       lowered.includes("foundations") ||
       lowered.includes("review & deepen") ||
       lowered.includes("advanced mastery") ||
@@ -580,7 +701,7 @@ export function useContentManagement() {
           "/api/questions/unified?page=1&pageSize=2000&includePagination=false",
           "Failed to fetch questions",
         ),
-        loadApiCollection<AdminCategory>(
+        loadApiCollection<DatabaseCategoryRecord>(
           "/api/categories",
           "Failed to fetch categories",
         ),
@@ -598,10 +719,19 @@ export function useContentManagement() {
         topicsResult.error,
       ].filter((message): message is string => Boolean(message));
 
-      setCards(cardsResult.data);
+      const canonicalCardsResult = buildCanonicalCards(cardsResult.data);
+      const mappedCategories = categoriesResult.data.map((category) => {
+        const inferred = inferCardKeyFromCategory(category);
+        return {
+          ...category,
+          learning_card_id: canonicalCardsResult.idsByKey[inferred],
+        };
+      });
+
+      setCards(canonicalCardsResult.cards);
       setPlans(plansResult.data);
       setQuestions(questionsResult.data);
-      setCategories(categoriesResult.data);
+      setCategories(mappedCategories);
       setTopics(topicsResult.data.map(transformTopicToAdmin));
 
       if (dataErrors.length > 0) {

--- a/apps/admin/src/app/admin/content-management/hooks/useContentManagement.ts
+++ b/apps/admin/src/app/admin/content-management/hooks/useContentManagement.ts
@@ -204,6 +204,15 @@ function buildCanonicalCards(cards: AdminLearningCard[]): {
   return { cards: canonicalCards, idsByKey };
 }
 
+function toSlug(input: string): string {
+  return input
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+}
+
 function generatePlanMetadata(sequence: number): PlanGenerationMetadata {
   switch (sequence) {
     case 1:
@@ -719,29 +728,53 @@ export function useContentManagement() {
         topicsResult.error,
       ].filter((message): message is string => Boolean(message));
 
-      const canonicalCardsResult = buildCanonicalCards(cardsResult.data);
+      const normalizedCards = cardsResult.data;
+      const canonicalCardsResult = buildCanonicalCards(normalizedCards);
+
       const mappedCategories = categoriesResult.data.map((category) => {
+        // Preserve DB relationship first. Only infer a fallback when missing.
+        if ((category as AdminCategory).learning_card_id) {
+          return category as AdminCategory;
+        }
+
         const inferred = inferCardKeyFromCategory(category);
         return {
           ...category,
           learning_card_id: canonicalCardsResult.idsByKey[inferred],
-        };
+        } as AdminCategory;
       });
 
-      setCards(canonicalCardsResult.cards);
+      setCards(normalizedCards);
       setPlans(plansResult.data);
       setQuestions(questionsResult.data);
       setCategories(mappedCategories);
       setTopics(topicsResult.data.map(transformTopicToAdmin));
+
+      const { data: existingPlanQuestions, error: planQuestionsError } =
+        await supabase.from("plan_questions").select("plan_id, question_id");
+
+      if (planQuestionsError) {
+        console.error(
+          "❌ Failed to fetch plan-question links:",
+          planQuestionsError,
+        );
+      } else {
+        const planQuestionKeys = new Set(
+          (existingPlanQuestions ?? []).map(
+            (row) => `${row.plan_id}-${row.question_id}`,
+          ),
+        );
+        setPlanQuestions(planQuestionKeys);
+      }
 
       if (dataErrors.length > 0) {
         console.error("❌ Content management partial load errors:", dataErrors);
         toast.error("Some content management data could not be loaded");
       }
 
-      // ARCHITECTURAL: Fetch plan-question associations from planRepository.getPlanQuestions()
-      // Requires implementing new repository method for plan-question relationships
-      setPlanQuestions(new Set());
+      if (!existingPlanQuestions || existingPlanQuestions.length === 0) {
+        setPlanQuestions(new Set());
+      }
     } catch (err) {
       console.error("❌ Error fetching data:", err);
       setError(err instanceof Error ? err.message : "Failed to fetch data");
@@ -1124,6 +1157,188 @@ export function useContentManagement() {
     }
   }, [cards, fetchData, plans, questions]);
 
+  const createCategory = useCallback(async () => {
+    const name = globalThis.prompt("Category name");
+    if (!name || !name.trim()) {
+      return;
+    }
+
+    const description =
+      globalThis.prompt("Category description (optional)") || "";
+
+    const defaultCardId = cards[0]?.id;
+    const payload: Record<string, unknown> = {
+      name: name.trim(),
+      description,
+      slug: toSlug(name),
+      is_active: true,
+    };
+
+    if (defaultCardId) {
+      payload.learning_card_id = defaultCardId;
+    }
+
+    const { error: createError } = await supabase
+      .from("categories")
+      .insert(payload);
+
+    if (createError) {
+      toast.error(createError.message || "Failed to create category");
+      return;
+    }
+
+    toast.success("Category created");
+    await fetchData();
+  }, [cards, fetchData]);
+
+  const editCategory = useCallback(
+    async (category: AdminCategory) => {
+      const nextName = globalThis.prompt("Category name", category.name ?? "");
+      if (!nextName || !nextName.trim()) {
+        return;
+      }
+
+      const nextDescription =
+        globalThis.prompt("Category description", category.description ?? "") ??
+        "";
+
+      const { error: updateError } = await supabase
+        .from("categories")
+        .update({
+          name: nextName.trim(),
+          description: nextDescription,
+          slug: toSlug(nextName),
+        })
+        .eq("id", category.id);
+
+      if (updateError) {
+        toast.error(updateError.message || "Failed to update category");
+        return;
+      }
+
+      toast.success("Category updated");
+      await fetchData();
+    },
+    [fetchData],
+  );
+
+  const removeCategory = useCallback(
+    async (category: AdminCategory) => {
+      const confirmed = globalThis.confirm(
+        `Delete category \"${category.name}\"?`,
+      );
+      if (!confirmed) {
+        return;
+      }
+
+      const { error: deleteError } = await supabase
+        .from("categories")
+        .delete()
+        .eq("id", category.id);
+
+      if (deleteError) {
+        toast.error(deleteError.message || "Failed to delete category");
+        return;
+      }
+
+      toast.success("Category deleted");
+      await fetchData();
+    },
+    [fetchData],
+  );
+
+  const createTopic = useCallback(async () => {
+    if (categories.length === 0) {
+      toast.error("Create a category first");
+      return;
+    }
+
+    const name = globalThis.prompt("Topic name");
+    if (!name || !name.trim()) {
+      return;
+    }
+
+    const description = globalThis.prompt("Topic description (optional)") || "";
+    const categoryId = categories[0]?.id;
+
+    if (!categoryId) {
+      toast.error("No category available for topic assignment");
+      return;
+    }
+
+    const payload = {
+      name: name.trim(),
+      description,
+      category_id: categoryId,
+      is_active: true,
+      order_index: 0,
+    };
+
+    const { error: createError } = await supabase
+      .from("topics")
+      .insert(payload);
+
+    if (createError) {
+      toast.error(createError.message || "Failed to create topic");
+      return;
+    }
+
+    toast.success("Topic created");
+    await fetchData();
+  }, [categories, fetchData]);
+
+  const editTopic = useCallback(
+    async (topic: AdminTopic) => {
+      const nextName = globalThis.prompt("Topic name", topic.name ?? "");
+      if (!nextName || !nextName.trim()) {
+        return;
+      }
+
+      const nextDescription =
+        globalThis.prompt("Topic description", topic.description ?? "") ?? "";
+
+      const { error: updateError } = await supabase
+        .from("topics")
+        .update({
+          name: nextName.trim(),
+          description: nextDescription,
+        })
+        .eq("id", topic.id);
+
+      if (updateError) {
+        toast.error(updateError.message || "Failed to update topic");
+        return;
+      }
+
+      toast.success("Topic updated");
+      await fetchData();
+    },
+    [fetchData],
+  );
+
+  const removeTopic = useCallback(
+    async (topic: AdminTopic) => {
+      const confirmed = globalThis.confirm(`Delete topic \"${topic.name}\"?`);
+      if (!confirmed) {
+        return;
+      }
+
+      const { error: deleteError } = await supabase
+        .from("topics")
+        .delete()
+        .eq("id", topic.id);
+
+      if (deleteError) {
+        toast.error(deleteError.message || "Failed to delete topic");
+        return;
+      }
+
+      toast.success("Topic deleted");
+      await fetchData();
+    },
+    [fetchData],
+  );
+
   return {
     cards,
     plans,
@@ -1185,5 +1400,11 @@ export function useContentManagement() {
     toggleCardActiveStatus,
     openTopicQuestionsModal,
     createSpacedRepetitionPlans,
+    createCategory,
+    editCategory,
+    removeCategory,
+    createTopic,
+    editTopic,
+    removeTopic,
   };
 }

--- a/apps/admin/src/app/admin/content-management/page.integration.test.tsx
+++ b/apps/admin/src/app/admin/content-management/page.integration.test.tsx
@@ -6,6 +6,14 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { vi, describe, it, expect, beforeEach } from "vitest";
 import ContentManagementPage from "./page";
 
+const mockRouterPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+  }),
+}));
+
 // Mock the content management hook
 const mockUseContentManagement = vi.fn();
 vi.mock("./hooks/useContentManagement", () => ({
@@ -62,70 +70,87 @@ vi.mock("@elzatona/common-ui", () => ({
 }));
 
 describe("Admin content management page - Integration", () => {
+  const buildHookState = () => ({
+    loading: false,
+    error: null,
+    searchTerm: "",
+    setSearchTerm: vi.fn(),
+    filterCardType: "all",
+    setFilterCardType: vi.fn(),
+    stats: {
+      cards: 25,
+      plans: 5,
+      categories: 8,
+      topics: 15,
+    },
+    filteredCards: [],
+    filteredPlans: [],
+    categories: [],
+    topics: [],
+    questions: [],
+    planQuestions: new Set(),
+    expandedCards: new Set(),
+    toggleCard: vi.fn(),
+    expandedCategories: new Set(),
+    toggleCategory: vi.fn(),
+    expandedTopics: new Set(),
+    toggleTopic: vi.fn(),
+    expandedPlans: new Set(),
+    togglePlan: vi.fn(),
+    expandedPlanCards: new Set(),
+    togglePlanCard: vi.fn(),
+    expandedPlanCategories: new Set(),
+    togglePlanCategory: vi.fn(),
+    expandedPlanTopics: new Set(),
+    togglePlanTopic: vi.fn(),
+    isTopicQuestionsModalOpen: false,
+    setIsTopicQuestionsModalOpen: vi.fn(),
+    selectedTopic: null,
+    selectedPlan: null,
+    selectedQuestions: new Set(),
+    toggleQuestionSelection: vi.fn(),
+    selectAllQuestions: vi.fn(),
+    deselectAllQuestions: vi.fn(),
+    addSelectedQuestionsToPlan: vi.fn(),
+    closeTopicQuestionsModal: vi.fn(),
+    isDeleteCardModalOpen: false,
+    setIsDeleteCardModalOpen: vi.fn(),
+    cardToDelete: null,
+    isDeleting: false,
+    openDeleteCardModal: vi.fn(),
+    closeDeleteCardModal: vi.fn(),
+    deleteCard: vi.fn(),
+    isCardManagementModalOpen: false,
+    setIsCardManagementModalOpen: vi.fn(),
+    selectedPlanForCards: null,
+    planCards: [],
+    availableCards: [],
+    isManagingCards: false,
+    openCardManagementModal: vi.fn(),
+    closeCardManagementModal: vi.fn(),
+    addCardToPlan: vi.fn(),
+    removeCardFromPlan: vi.fn(),
+    toggleCardActiveStatus: vi.fn(),
+    openTopicQuestionsModal: vi.fn(),
+    createSpacedRepetitionPlans: vi.fn(),
+    createCategory: vi.fn(),
+    editCategory: vi.fn(),
+    removeCategory: vi.fn(),
+    createTopic: vi.fn(),
+    editTopic: vi.fn(),
+    removeTopic: vi.fn(),
+  });
+
   beforeEach(() => {
-    mockUseContentManagement.mockReturnValue({
-      loading: false,
-      error: null,
-      searchTerm: "",
-      setSearchTerm: vi.fn(),
-      filterCardType: "all",
-      setFilterCardType: vi.fn(),
-      stats: {
-        totalCards: 25,
-        totalPlans: 5,
-        totalCategories: 8,
-        totalTopics: 15,
-      },
-      filteredCards: [],
-      filteredPlans: [],
-      categories: [],
-      topics: [],
-      questions: [],
-      // planQuestions present above; avoid duplicate property
-      expandedCards: new Set(),
-      toggleCard: vi.fn(),
-      expandedCategories: new Set(),
-      toggleCategory: vi.fn(),
-      expandedTopics: new Set(),
-      toggleTopic: vi.fn(),
-      expandedPlans: new Set(),
-      togglePlan: vi.fn(),
-      expandedPlanCards: new Set(),
-      togglePlanCard: vi.fn(),
-      expandedPlanCategories: new Set(),
-      togglePlanCategory: vi.fn(),
-      expandedPlanTopics: new Set(),
-      togglePlanTopic: vi.fn(),
-      isTopicQuestionsModalOpen: false,
-      setIsTopicQuestionsModalOpen: vi.fn(),
-      selectedTopic: null,
-      setSelectedTopic: vi.fn(),
-      isDeleteModalOpen: false,
-      setIsDeleteModalOpen: vi.fn(),
-      itemToDelete: null,
-      setItemToDelete: vi.fn(),
-      handleDelete: vi.fn(),
-      isCardManagementModalOpen: false,
-      setIsCardManagementModalOpen: vi.fn(),
-      selectedCard: null,
-      setSelectedCard: vi.fn(),
-      availableCards: [],
-      isManagingCards: false,
-      setIsManagingCards: vi.fn(),
-      planQuestions: new Set(),
-    });
+    mockUseContentManagement.mockReturnValue(buildHookState());
   });
 
   it("renders content management page with stats", () => {
     render(<ContentManagementPage />);
 
     expect(screen.getByTestId("stats-section")).toBeInTheDocument();
-    expect(screen.getByTestId("stat-totalCards")).toHaveTextContent(
-      "totalCards: 25",
-    );
-    expect(screen.getByTestId("stat-totalPlans")).toHaveTextContent(
-      "totalPlans: 5",
-    );
+    expect(screen.getByTestId("stat-cards")).toHaveTextContent("cards: 25");
+    expect(screen.getByTestId("stat-plans")).toHaveTextContent("plans: 5");
   });
 
   it("renders search and filter components", () => {
@@ -147,7 +172,7 @@ describe("Admin content management page - Integration", () => {
 
   it("shows loading state", () => {
     mockUseContentManagement.mockReturnValue({
-      ...mockUseContentManagement(),
+      ...buildHookState(),
       loading: true,
     });
 
@@ -158,7 +183,7 @@ describe("Admin content management page - Integration", () => {
 
   it("displays error message when error occurs", () => {
     mockUseContentManagement.mockReturnValue({
-      ...mockUseContentManagement(),
+      ...buildHookState(),
       error: "Failed to load content data",
     });
 
@@ -172,7 +197,7 @@ describe("Admin content management page - Integration", () => {
   it("search functionality updates search term", () => {
     const mockSetSearchTerm = vi.fn();
     mockUseContentManagement.mockReturnValue({
-      ...mockUseContentManagement(),
+      ...buildHookState(),
       setSearchTerm: mockSetSearchTerm,
     });
 
@@ -187,7 +212,7 @@ describe("Admin content management page - Integration", () => {
   it("filter functionality updates filter type", () => {
     const mockSetFilterCardType = vi.fn();
     mockUseContentManagement.mockReturnValue({
-      ...mockUseContentManagement(),
+      ...buildHookState(),
       setFilterCardType: mockSetFilterCardType,
     });
 
@@ -201,9 +226,9 @@ describe("Admin content management page - Integration", () => {
 
   it("renders modal components when open", () => {
     mockUseContentManagement.mockReturnValue({
-      ...mockUseContentManagement(),
+      ...buildHookState(),
       isTopicQuestionsModalOpen: true,
-      isDeleteModalOpen: true,
+      isDeleteCardModalOpen: true,
       isCardManagementModalOpen: true,
     });
 

--- a/apps/admin/src/app/admin/content-management/page.test.tsx
+++ b/apps/admin/src/app/admin/content-management/page.test.tsx
@@ -10,6 +10,14 @@ import ContentManagementPage from "./page";
 import "@testing-library/jest-dom";
 import { useContentManagement } from "./hooks/useContentManagement";
 
+const mockRouterPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+  }),
+}));
+
 // Mock the hook
 vi.mock("./hooks/useContentManagement", () => ({
   useContentManagement: vi.fn(),
@@ -130,33 +138,49 @@ describe("ContentManagementPage", () => {
     expandedPlanCards: new Set(),
     expandedPlanCategories: new Set(),
     expandedPlanTopics: new Set(),
-    showTopicQuestionsModal: false,
-    setShowTopicQuestionsModal: vi.fn(),
+    isTopicQuestionsModalOpen: false,
+    setIsTopicQuestionsModalOpen: vi.fn(),
     selectedTopic: null,
-    setSelectedTopic: vi.fn(),
-    showDeleteModal: false,
-    setShowDeleteModal: vi.fn(),
-    deleteTarget: null,
-    setDeleteTarget: vi.fn(),
-    showCardModal: false,
-    setShowCardModal: vi.fn(),
-    editingCard: null,
-    setEditingCard: vi.fn(),
-    handleCardUpdate: vi.fn(),
-    handleCardDelete: vi.fn(),
-    handlePlanUpdate: vi.fn(),
-    handlePlanDelete: vi.fn(),
-    handleTopicUpdate: vi.fn(),
-    handleTopicDelete: vi.fn(),
-    handleCategoryUpdate: vi.fn(),
-    handleCategoryDelete: vi.fn(),
-    toggleCardExpansion: vi.fn(),
-    toggleCategoryExpansion: vi.fn(),
-    toggleTopicExpansion: vi.fn(),
-    togglePlanExpansion: vi.fn(),
-    togglePlanCardExpansion: vi.fn(),
-    togglePlanCategoryExpansion: vi.fn(),
-    togglePlanTopicExpansion: vi.fn(),
+    selectedPlan: null,
+    selectedQuestions: new Set(),
+    toggleQuestionSelection: vi.fn(),
+    selectAllQuestions: vi.fn(),
+    deselectAllQuestions: vi.fn(),
+    addSelectedQuestionsToPlan: vi.fn(),
+    closeTopicQuestionsModal: vi.fn(),
+    isDeleteCardModalOpen: false,
+    setIsDeleteCardModalOpen: vi.fn(),
+    cardToDelete: null,
+    isDeleting: false,
+    openDeleteCardModal: vi.fn(),
+    closeDeleteCardModal: vi.fn(),
+    deleteCard: vi.fn(),
+    isCardManagementModalOpen: false,
+    setIsCardManagementModalOpen: vi.fn(),
+    selectedPlanForCards: null,
+    planCards: [],
+    availableCards: [],
+    isManagingCards: false,
+    openCardManagementModal: vi.fn(),
+    closeCardManagementModal: vi.fn(),
+    addCardToPlan: vi.fn(),
+    removeCardFromPlan: vi.fn(),
+    toggleCardActiveStatus: vi.fn(),
+    openTopicQuestionsModal: vi.fn(),
+    createSpacedRepetitionPlans: vi.fn(),
+    createCategory: vi.fn(),
+    editCategory: vi.fn(),
+    removeCategory: vi.fn(),
+    createTopic: vi.fn(),
+    editTopic: vi.fn(),
+    removeTopic: vi.fn(),
+    toggleCard: vi.fn(),
+    toggleCategory: vi.fn(),
+    toggleTopic: vi.fn(),
+    togglePlan: vi.fn(),
+    togglePlanCard: vi.fn(),
+    togglePlanCategory: vi.fn(),
+    togglePlanTopic: vi.fn(),
   };
 
   beforeEach(() => {
@@ -307,7 +331,7 @@ describe("ContentManagementPage", () => {
     it("should render topic questions modal when showTopicQuestionsModal is true", () => {
       vi.mocked(useContentManagement).mockReturnValue({
         ...mockHookReturn,
-        showTopicQuestionsModal: true,
+        isTopicQuestionsModalOpen: true,
       } as any);
 
       render(<ContentManagementPage />);
@@ -318,7 +342,7 @@ describe("ContentManagementPage", () => {
     it("should render delete confirmation modal when showDeleteModal is true", () => {
       vi.mocked(useContentManagement).mockReturnValue({
         ...mockHookReturn,
-        showDeleteModal: true,
+        isDeleteCardModalOpen: true,
       } as any);
 
       render(<ContentManagementPage />);
@@ -331,7 +355,7 @@ describe("ContentManagementPage", () => {
     it("should render card management modal when showCardModal is true", () => {
       vi.mocked(useContentManagement).mockReturnValue({
         ...mockHookReturn,
-        showCardModal: true,
+        isCardManagementModalOpen: true,
       } as any);
 
       render(<ContentManagementPage />);

--- a/apps/admin/src/app/admin/content-management/page.tsx
+++ b/apps/admin/src/app/admin/content-management/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { useRouter } from "next/navigation";
 import {
   Button,
   StatsSection,
@@ -17,6 +18,7 @@ import { Loader2 } from "lucide-react";
 import { useContentManagement } from "./hooks/useContentManagement";
 
 export default function ContentManagementPage() {
+  const router = useRouter();
   const {
     loading,
     error,
@@ -75,6 +77,12 @@ export default function ContentManagementPage() {
     toggleCardActiveStatus,
     openTopicQuestionsModal,
     createSpacedRepetitionPlans,
+    createCategory,
+    editCategory,
+    removeCategory,
+    createTopic,
+    editTopic,
+    removeTopic,
   } = useContentManagement();
 
   if (loading) {
@@ -155,19 +163,29 @@ export default function ContentManagementPage() {
         {/* Topics Management Section */}
         <TopicsManager
           topics={topics}
-          onCreateTopic={() => console.log("Create topic")}
-          onEditTopic={(topic) => console.log("Edit topic", topic)}
-          onDeleteTopic={(topic) => console.log("Delete topic", topic)}
+          onCreateTopic={() => {
+            void createTopic();
+          }}
+          onEditTopic={(topic: any) => {
+            void editTopic(topic);
+          }}
+          onDeleteTopic={(topic: any) => {
+            void removeTopic(topic);
+          }}
         />
 
         {/* Categories Management Section */}
         <CategoriesManager
           categories={categories}
-          onCreateCategory={() => console.log("Create category")}
-          onEditCategory={(category) => console.log("Edit category", category)}
-          onDeleteCategory={(category) =>
-            console.log("Delete category", category)
-          }
+          onCreateCategory={() => {
+            void createCategory();
+          }}
+          onEditCategory={(category: any) => {
+            void editCategory(category);
+          }}
+          onDeleteCategory={(category: any) => {
+            void removeCategory(category);
+          }}
         />
 
         {/* Learning Cards Section */}
@@ -183,10 +201,14 @@ export default function ContentManagementPage() {
           toggleCategory={toggleCategory}
           expandedTopics={expandedTopics}
           toggleTopic={toggleTopic}
-          onEditCard={(card) => console.log("Edit card", card)}
+          onEditCard={(card) =>
+            router.push(
+              `/admin/learning-cards?edit=${encodeURIComponent(card.id)}`,
+            )
+          }
           onDeleteCard={openDeleteCardModal}
-          onCreateCard={() => console.log("Create card")}
-          onEditCategories={() => console.log("Edit categories")}
+          onCreateCard={() => router.push("/admin/learning-cards")}
+          onEditCategories={() => router.push("/admin/learning-cards")}
         />
 
         {/* Learning Plans Section */}
@@ -195,6 +217,7 @@ export default function ContentManagementPage() {
           cards={filteredCards}
           categories={categories}
           topics={topics}
+          questions={questions}
           stats={stats}
           planQuestions={planQuestions}
           expandedPlans={expandedPlans}
@@ -205,8 +228,16 @@ export default function ContentManagementPage() {
           togglePlanCategory={togglePlanCategory}
           expandedPlanTopics={expandedPlanTopics}
           togglePlanTopic={togglePlanTopic}
-          onEditPlan={(plan) => console.log("Edit plan", plan)}
-          onDeletePlan={(plan) => console.log("Delete plan", plan)}
+          onEditPlan={(plan) =>
+            globalThis.alert(
+              `Plan editing from this screen is coming soon: ${plan.name}`,
+            )
+          }
+          onDeletePlan={(plan) =>
+            globalThis.alert(
+              `Plan deletion from this screen is coming soon: ${plan.name}`,
+            )
+          }
           onCreatePlan={createSpacedRepetitionPlans}
           onManageCards={openCardManagementModal}
           openTopicQuestionsModal={openTopicQuestionsModal}

--- a/libs/common-ui/src/admin/content-management/LearningCardsManager.tsx
+++ b/libs/common-ui/src/admin/content-management/LearningCardsManager.tsx
@@ -46,13 +46,6 @@ function countQuestionsForCategory(
   return questions.filter((q) => q.category_id === categoryId).length;
 }
 
-function countQuestionsForTopic(
-  topicId: string,
-  questions: AdminQuestion[],
-): number {
-  return questions.filter((q) => q.topic_id === topicId).length;
-}
-
 import React from "react";
 import {
   Card,
@@ -105,6 +98,8 @@ const TopicNode: React.FC<{
   expandedTopics: Set<string>;
   toggleTopic: (id: string) => void;
 }> = ({ topic, questions, expandedTopics, toggleTopic }) => {
+  const topicQuestions = questions.filter((q) => q.topic_id === topic.id);
+
   return (
     <div className="border-l-2 border-gray-100 pl-4 py-2">
       <div className="flex items-center justify-between">
@@ -132,10 +127,36 @@ const TopicNode: React.FC<{
             variant="outline"
             className="bg-green-50 text-green-700 dark:bg-green-900 dark:text-green-300"
           >
-            {countQuestionsForTopic(topic.id, questions)} Questions
+            {topicQuestions.length} Questions
           </Badge>
         </div>
       </div>
+
+      {expandedTopics.has(topic.id) && (
+        <div className="mt-2 ml-8 space-y-1">
+          {topicQuestions.length === 0 ? (
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              No questions assigned to this topic yet.
+            </p>
+          ) : (
+            topicQuestions.map((question) => (
+              <div
+                key={question.id}
+                className="rounded border border-gray-200 dark:border-gray-700 px-2 py-1 text-xs"
+              >
+                <p className="font-medium text-gray-900 dark:text-white">
+                  {question.title}
+                </p>
+                {question.difficulty && (
+                  <p className="text-gray-500 dark:text-gray-400">
+                    {question.difficulty}
+                  </p>
+                )}
+              </div>
+            ))
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/libs/common-ui/src/admin/content-management/PlansManager.tsx
+++ b/libs/common-ui/src/admin/content-management/PlansManager.tsx
@@ -40,6 +40,7 @@ import {
   AdminLearningCard,
   AdminCategory,
   Topic,
+  AdminQuestion,
   ContentManagementStats,
 } from "@elzatona/types";
 
@@ -56,6 +57,7 @@ interface PlansManagerProps {
   cards: AdminLearningCard[];
   categories: AdminCategory[];
   topics: Topic[];
+  questions: AdminQuestion[];
   stats: ContentManagementStats;
   planQuestions: Set<string>;
   expandedPlans: Set<string>;
@@ -76,6 +78,8 @@ interface PlansManagerProps {
 const PlanTopicNode: React.FC<{
   topic: Topic;
   plan: LearningPlan;
+  questions: AdminQuestion[];
+  planQuestions: Set<string>;
   expandedPlanTopics: Set<string>;
   togglePlanTopic: (id: string) => void;
   openTopicQuestionsModal: (topic: Topic, plan: LearningPlan) => void;
@@ -83,11 +87,17 @@ const PlanTopicNode: React.FC<{
 }> = ({
   topic,
   plan,
+  questions,
+  planQuestions,
   expandedPlanTopics,
   togglePlanTopic,
   openTopicQuestionsModal,
   selectedQuestionsCount,
 }) => {
+  const topicQuestions = questions.filter((question) => {
+    return question.topic_id === topic.id;
+  });
+
   return (
     <div className="border-l-2 border-orange-100 pl-4 py-1">
       <div className="flex items-center justify-between">
@@ -119,6 +129,43 @@ const PlanTopicNode: React.FC<{
           </Badge>
         </div>
       </div>
+
+      {expandedPlanTopics.has(topic.id) && (
+        <div className="ml-8 mt-2 space-y-1">
+          {topicQuestions.length === 0 ? (
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              No questions in this topic.
+            </p>
+          ) : (
+            topicQuestions.map((question) => {
+              const inPlan = planQuestions.has(`${plan.id}-${question.id}`);
+
+              return (
+                <div
+                  key={question.id}
+                  className="rounded border border-gray-200 dark:border-gray-700 px-2 py-1 text-xs"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <p className="font-medium text-gray-900 dark:text-white">
+                      {question.title}
+                    </p>
+                    <Badge
+                      variant="outline"
+                      className={
+                        inPlan
+                          ? "bg-green-50 text-green-700"
+                          : "bg-gray-50 text-gray-600"
+                      }
+                    >
+                      {inPlan ? "In Plan" : "Available"}
+                    </Badge>
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+      )}
     </div>
   );
 };
@@ -127,6 +174,8 @@ const PlanCategoryNode: React.FC<{
   category: AdminCategory;
   categoryTopics: Topic[];
   plan: LearningPlan;
+  questions: AdminQuestion[];
+  planQuestions: Set<string>;
   expandedPlanCategories: Set<string>;
   togglePlanCategory: (id: string) => void;
   expandedPlanTopics: Set<string>;
@@ -137,6 +186,8 @@ const PlanCategoryNode: React.FC<{
   category,
   categoryTopics,
   plan,
+  questions,
+  planQuestions,
   expandedPlanCategories,
   togglePlanCategory,
   expandedPlanTopics,
@@ -173,6 +224,8 @@ const PlanCategoryNode: React.FC<{
               key={topic.id}
               topic={topic}
               plan={plan}
+              questions={questions}
+              planQuestions={planQuestions}
               expandedPlanTopics={expandedPlanTopics}
               togglePlanTopic={togglePlanTopic}
               openTopicQuestionsModal={openTopicQuestionsModal}
@@ -190,6 +243,7 @@ export const PlansManager: React.FC<PlansManagerProps> = ({
   cards,
   categories,
   topics,
+  questions,
   stats,
   planQuestions,
   expandedPlans,
@@ -224,6 +278,8 @@ export const PlansManager: React.FC<PlansManagerProps> = ({
         category={category}
         categoryTopics={categoryTopics}
         plan={plan}
+        questions={questions}
+        planQuestions={planQuestions}
         expandedPlanCategories={expandedPlanCategories}
         togglePlanCategory={togglePlanCategory}
         expandedPlanTopics={expandedPlanTopics}

--- a/tools/cleanup-bug-issues.sh
+++ b/tools/cleanup-bug-issues.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Script to bulk close GitHub issues with the 'bugs' label
+# Usage: ./tools/cleanup-bug-issues.sh [--delete] [--dry-run]
+
+LABEL="bugs"
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+ACTION="close"
+DRY_RUN=false
+
+FORCE=false
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --delete) ACTION="delete" ;;
+        --dry-run) DRY_RUN=true ;;
+        --yes) FORCE=true ;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+while true; do
+echo "🔍 Fetching open issues with label '$LABEL' in $REPO..."
+
+# Get issue numbers
+ISSUES=$(gh issue list --label "$LABEL" --state open --limit 1000 --json number --jq '.[].number')
+COUNT=$(echo "$ISSUES" | wc -w | tr -d ' ')
+
+if [ "$COUNT" -eq 0 ]; then
+    echo "✅ No more open issues found with label '$LABEL'."
+    break
+fi
+
+echo "⚠️  Found $COUNT issues to $ACTION."
+
+if [ "$DRY_RUN" = true ]; then
+    echo "✨ Dry run: The following issue numbers would be ${ACTION}d:"
+    echo "$ISSUES"
+    exit 0
+fi
+
+if [ "$FORCE" = false ]; then
+    read -p "Are you sure you want to $ACTION $COUNT issues? (y/N) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "❌ Operation cancelled."
+        exit 1
+    fi
+    FORCE=true # Don't ask again for next batches
+fi
+
+if [ "$ACTION" == "delete" ]; then
+    echo "$ISSUES" | xargs -n 1 -P 5 -I {} sh -c "echo '🗑️ Deleting issue #{}...' && gh issue delete '{}' --confirm"
+else
+    # Closing without comment to avoid secondary rate limits
+    echo "$ISSUES" | xargs -n 1 -P 5 -I {} sh -c "echo '🔒 Closing issue #{}...' && gh issue close '{}' --reason 'not planned'"
+fi
+
+echo "✅ Finished ${ACTION}ing batch of $COUNT issues."
+done

--- a/tools/code-scanning-batch-flow.sh
+++ b/tools/code-scanning-batch-flow.sh
@@ -1,0 +1,285 @@
+#!/bin/bash
+
+set -euo pipefail
+
+MODE="${1:-start}"
+BRANCH_PREFIX="${BRANCH_PREFIX:-fix/code-scanning-bugs}"
+ISSUE_LIMIT="${ISSUE_LIMIT:-500}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/code-scanning-batch-flow.sh start
+  bash scripts/code-scanning-batch-flow.sh pr
+
+Modes:
+  start   Sync local main with origin/main, create a fresh branch, and generate
+          a remediation report for open code-scanning alerts + open "bugs" issues.
+  pr      Push current branch and create PR to main.
+
+Environment variables:
+  BRANCH_PREFIX   Prefix for new remediation branches (default: fix/code-scanning-bugs)
+  ISSUE_LIMIT     Max number of open "bugs" issues to fetch (default: 500)
+  PR_TITLE        Optional title for pr mode
+  PR_BODY_FILE    Optional markdown file for PR body in pr mode
+
+Examples:
+  bash scripts/code-scanning-batch-flow.sh start
+  PR_TITLE="fix(code-scanning): resolve batch alerts" bash scripts/code-scanning-batch-flow.sh pr
+EOF
+}
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo -e "${RED}❌ Missing required command: ${cmd}${NC}"
+    exit 1
+  fi
+}
+
+ensure_clean_worktree() {
+  if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo -e "${RED}❌ Working tree is not clean.${NC}"
+    echo -e "${YELLOW}   Commit or stash changes before starting a new code-scanning batch.${NC}"
+    exit 1
+  fi
+}
+
+repo_name_with_owner() {
+  gh repo view --json nameWithOwner --jq '.nameWithOwner'
+}
+
+count_open_code_scanning_alerts() {
+  local repo="$1"
+  local page=1
+  local total=0
+  local alerts_file="$2"
+
+  : > "$alerts_file"
+
+  while true; do
+    local response
+    response=$(gh api "/repos/${repo}/code-scanning/alerts?state=open&per_page=100&page=${page}")
+    local page_count
+    page_count=$(echo "$response" | jq 'length')
+
+    if [[ "$page_count" -eq 0 ]]; then
+      break
+    fi
+
+    total=$((total + page_count))
+
+    echo "$response" | jq -r '.[] | [
+      .number,
+      .rule.id,
+      .rule.security_severity_level,
+      .most_recent_instance.location.path
+    ] | @tsv' >> "$alerts_file"
+
+    if [[ "$page_count" -lt 100 ]]; then
+      break
+    fi
+
+    page=$((page + 1))
+  done
+
+  echo "$total"
+}
+
+create_start_report() {
+  local branch_name="$1"
+  local repo="$2"
+  local issues_json="$3"
+  local issues_count="$4"
+  local alerts_count="$5"
+  local alerts_file="$6"
+  local timestamp="$7"
+  local report_file="docs/security/CODESCANNING_BATCH_${timestamp}.md"
+
+  cat > "$report_file" <<EOF
+# Code Scanning Remediation Batch
+
+## Scope
+
+- Repository: ${repo}
+- Branch: ${branch_name}
+- Open code-scanning alerts: ${alerts_count}
+- Open issues with label bugs: ${issues_count}
+
+## Required Flow
+
+1. Started from latest main.
+2. Created a dedicated remediation branch.
+3. Fix code-scanning issues.
+4. Commit and push branch.
+5. Open PR to main.
+6. After merge, linked issues are closed/deleted by workflow.
+
+## bugs Issues (Open)
+
+EOF
+
+  if [[ "$issues_count" -gt 0 ]]; then
+    echo "$issues_json" | jq -r '.[] | "- [ ] #\(.number) \(.title) (\(.url))"' >> "$report_file"
+  else
+    echo "- None" >> "$report_file"
+  fi
+
+  cat >> "$report_file" <<EOF
+
+## Code Scanning Alerts Snapshot
+
+EOF
+
+  if [[ "$alerts_count" -gt 0 ]]; then
+    {
+      echo "| Alert | Rule | Severity | File |"
+      echo "|---|---|---|---|"
+      head -n 100 "$alerts_file" | awk -F'\t' '{printf "| #%s | %s | %s | %s |\n", $1, $2, $3, $4}'
+    } >> "$report_file"
+
+    if [[ "$alerts_count" -gt 100 ]]; then
+      echo "" >> "$report_file"
+      echo "- Showing first 100 alerts only (total open: ${alerts_count})." >> "$report_file"
+    fi
+  else
+    echo "- None" >> "$report_file"
+  fi
+
+  cat >> "$report_file" <<EOF
+
+## Next Command
+
+After you finish fixes and commit on ${branch_name}:
+
+\`bash scripts/code-scanning-batch-flow.sh pr\`
+EOF
+
+  echo "$report_file"
+}
+
+run_start() {
+  require_cmd git
+  require_cmd gh
+  require_cmd jq
+
+  ensure_clean_worktree
+
+  local repo
+  repo="$(repo_name_with_owner)"
+
+  echo -e "${BLUE}🔄 Syncing with origin/main...${NC}"
+  git fetch origin main
+  git checkout main
+  git pull --ff-only origin main
+
+  local timestamp
+  timestamp="$(date -u +%Y%m%d-%H%M%S)"
+  local branch_name
+  branch_name="${BRANCH_PREFIX}-${timestamp}"
+
+  echo -e "${BLUE}🌿 Creating branch ${branch_name}...${NC}"
+  git checkout -b "$branch_name"
+
+  echo -e "${BLUE}📥 Fetching open issues with label bugs...${NC}"
+  local issues_json
+  issues_json="$(gh issue list --repo "$repo" --state open --label bugs --limit "$ISSUE_LIMIT" --json number,title,url)"
+  local issues_count
+  issues_count="$(echo "$issues_json" | jq 'length')"
+
+  echo -e "${BLUE}🛡️ Fetching open code-scanning alerts...${NC}"
+  local alerts_file
+  alerts_file="$(mktemp)"
+  local alerts_count
+  alerts_count="$(count_open_code_scanning_alerts "$repo" "$alerts_file")"
+
+  local report_file
+  report_file="$(create_start_report "$branch_name" "$repo" "$issues_json" "$issues_count" "$alerts_count" "$alerts_file" "$timestamp")"
+
+  rm -f "$alerts_file"
+
+  echo -e "${GREEN}✅ Batch started successfully${NC}"
+  echo -e "${GREEN}   Branch: ${branch_name}${NC}"
+  echo -e "${GREEN}   Report: ${report_file}${NC}"
+}
+
+run_pr() {
+  require_cmd git
+  require_cmd gh
+
+  local current_branch
+  current_branch="$(git branch --show-current)"
+
+  if [[ "$current_branch" == "main" ]]; then
+    echo -e "${RED}❌ Current branch is main. Switch to a remediation branch first.${NC}"
+    exit 1
+  fi
+
+  if [[ -z "$(git log origin/main..HEAD --oneline 2>/dev/null || true)" ]]; then
+    echo -e "${RED}❌ No commits found ahead of origin/main on ${current_branch}.${NC}"
+    echo -e "${YELLOW}   Add fixes and commit before creating PR.${NC}"
+    exit 1
+  fi
+
+  echo -e "${BLUE}⬆️ Pushing branch ${current_branch}...${NC}"
+  git push -u origin "$current_branch"
+
+  local default_title
+  default_title="fix(code-scanning): resolve bugs batch on ${current_branch}"
+  local pr_title
+  pr_title="${PR_TITLE:-$default_title}"
+
+  local default_body_file
+  default_body_file="tmp/${current_branch//\//-}-pr-body.md"
+  local pr_body_file
+  pr_body_file="${PR_BODY_FILE:-$default_body_file}"
+
+  if [[ ! -f "$pr_body_file" ]]; then
+    mkdir -p tmp
+    cat > "$pr_body_file" <<EOF
+## Summary
+
+- Resolve code-scanning findings and related issues with label bugs.
+- Branch was created from latest main before applying fixes.
+
+## Related issues
+
+Add only issues fixed by this PR, for example:
+
+- Closes #1234
+- Closes #5678
+EOF
+  fi
+
+  echo -e "${BLUE}🧾 Creating PR to main...${NC}"
+  gh pr create \
+    --base main \
+    --head "$current_branch" \
+    --title "$pr_title" \
+    --body-file "$pr_body_file"
+
+  echo -e "${GREEN}✅ PR created targeting main.${NC}"
+}
+
+case "$MODE" in
+  start)
+    run_start
+    ;;
+  pr)
+    run_pr
+    ;;
+  -h|--help|help)
+    usage
+    ;;
+  *)
+    echo -e "${RED}❌ Unknown mode: ${MODE}${NC}"
+    usage
+    exit 1
+    ;;
+esac

--- a/tools/code-scanning-to-issues/.gitignore
+++ b/tools/code-scanning-to-issues/.gitignore
@@ -1,0 +1,16 @@
+# Dependencies
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Environment variables
+.env
+.env.local
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log

--- a/tools/code-scanning-to-issues/index.js
+++ b/tools/code-scanning-to-issues/index.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+/**
+ * Code Scanning to Issues Converter
+ *
+ * This script converts GitHub Code Scanning alerts into GitHub Issues
+ * for better tracking and management.
+ */
+
+const { Octokit } = require('@octokit/rest');
+
+// Get environment variables
+const token = process.env.REPO_TOKEN;
+const repository = process.env.GITHUB_REPOSITORY || process.env.GITHUB_REPO;
+const apiUrl = process.env.GITHUB_API_URL || 'https://api.github.com';
+
+if (!token) {
+  console.error('❌ Error: REPO_TOKEN environment variable is required');
+  console.error('Please set it with: export REPO_TOKEN=your_token_here');
+  process.exit(1);
+}
+
+if (!repository) {
+  console.error('❌ Error: GITHUB_REPOSITORY environment variable is required');
+  console.error('Please set it with: export GITHUB_REPOSITORY=owner/repo');
+  process.exit(1);
+}
+
+const [owner, repo] = repository.split('/');
+
+if (!owner || !repo) {
+  console.error('❌ Error: Invalid GITHUB_REPOSITORY format. Expected: owner/repo');
+  process.exit(1);
+}
+
+const octokit = new Octokit({
+  auth: token,
+  baseUrl: apiUrl,
+});
+
+async function getCodeScanningAlerts() {
+  try {
+    console.log(`🔍 Fetching code scanning alerts for ${owner}/${repo}...`);
+
+    const response = await octokit.request('GET /repos/{owner}/{repo}/code-scanning/alerts', {
+      owner,
+      repo,
+      per_page: 100,
+      state: 'open'
+    });
+
+    return response.data;
+  } catch (error) {
+    console.error('❌ Error fetching code scanning alerts:', error.message);
+    process.exit(1);
+  }
+}
+
+async function createIssueFromAlert(alert) {
+  const title = `[Code Scanning] ${alert.rule.name}`;
+  const body = `
+## Code Scanning Alert
+
+**Rule:** ${alert.rule.name}
+**Severity:** ${alert.rule.severity}
+**Description:** ${alert.rule.description}
+
+**File:** \`${alert.location?.path || 'Unknown'}\`
+**Line:** ${alert.location?.start_line || 'Unknown'}
+
+**Details:** ${alert.most_recent_instance?.message?.text || 'No details available'}
+
+**URL:** ${alert.html_url}
+
+---
+*This issue was automatically created from a Code Scanning alert.*
+  `.trim();
+
+  const labels = ['code-scanning', `severity-${alert.rule.severity}`];
+
+  try {
+    const response = await octokit.rest.issues.create({
+      owner,
+      repo,
+      title,
+      body,
+      labels
+    });
+
+    console.log(`✅ Created issue: ${response.data.html_url}`);
+    return response.data;
+  } catch (error) {
+    console.error(`❌ Error creating issue for alert ${alert.number}:`, error.message);
+    return null;
+  }
+}
+
+async function main() {
+  console.log('🚀 Starting Code Scanning to Issues conversion...');
+
+  const alerts = await getCodeScanningAlerts();
+
+  if (alerts.length === 0) {
+    console.log('ℹ️ No open code scanning alerts found.');
+    return;
+  }
+
+  console.log(`📋 Found ${alerts.length} open alerts. Creating issues...`);
+
+  for (const alert of alerts) {
+    await createIssueFromAlert(alert);
+    // Add a small delay to avoid rate limiting
+    await new Promise(resolve => setTimeout(resolve, 1000));
+  }
+
+  console.log('✅ Conversion complete!');
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error('💥 Unexpected error:', error);
+  process.exit(1);
+}

--- a/tools/purge-remote-branches.sh
+++ b/tools/purge-remote-branches.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# High-Performance Bulk Remote Branch Purge Script
+
+echo "🔍 Fetching remote branches..."
+git fetch origin --prune
+
+# Define protected branches
+PROTECTED_REGEX="^(main|develop|releases)$"
+
+# Get list of remote branches, filter out protected ones and HEAD
+REMOTE_BRANCHES=$(git branch -r | grep 'origin/' | grep -v 'origin/HEAD' | sed 's/origin\///' | sed 's/^[[:space:]]*//' | grep -vE "$PROTECTED_REGEX")
+
+if [ -z "$REMOTE_BRANCHES" ]; then
+    echo "✅ No branches to purge."
+    exit 0
+fi
+
+echo "🗑️ Starting parallelized remote purge..."
+# Use xargs to parallelize with 20 processes
+echo "$REMOTE_BRANCHES" | xargs -n 1 -P 20 -I {} sh -c "echo 'Deleting: {}' && git push origin --delete '{}' --no-verify"
+
+echo "✨ Finished! Running final prune..."
+git remote prune origin
+echo "✅ Done."

--- a/tools/reconcile-code-scanning-issues.sh
+++ b/tools/reconcile-code-scanning-issues.sh
@@ -1,0 +1,222 @@
+#!/bin/bash
+
+set -euo pipefail
+
+MODE="${1:-help}"
+APPLY_CHANGES="false"
+PR_NUMBER=""
+REPO="${REPO:-FoushWare/elzatona_web}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/reconcile-code-scanning-issues.sh resolved-by-pr --pr <number> [--apply]
+  bash scripts/reconcile-code-scanning-issues.sh dedupe-bugs [--apply]
+
+Modes:
+  resolved-by-pr   Find issues linked to a PR and close/delete matching code-scanning issues.
+  dedupe-bugs      Find duplicate open issues with label bugs by alert number and clean duplicates.
+
+Flags:
+  --pr <number>    Pull request number (required for resolved-by-pr mode)
+  --apply          Apply changes (default is dry-run)
+
+Examples:
+  bash scripts/reconcile-code-scanning-issues.sh resolved-by-pr --pr 7525
+  bash scripts/reconcile-code-scanning-issues.sh resolved-by-pr --pr 7525 --apply
+  bash scripts/reconcile-code-scanning-issues.sh dedupe-bugs
+  bash scripts/reconcile-code-scanning-issues.sh dedupe-bugs --apply
+EOF
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "❌ Missing required command: $1"
+    exit 1
+  fi
+}
+
+is_code_scanning_issue() {
+  local title="$1"
+  local labels_csv="$2"
+
+  if echo "$labels_csv" | tr ',' '\n' | grep -iq '^bugs$'; then
+    return 0
+  fi
+
+  if echo "$title" | grep -Eiq 'alert[[:space:]]*#[0-9]+'; then
+    return 0
+  fi
+
+  return 1
+}
+
+close_issue() {
+  local issue_number="$1"
+  local comment="$2"
+
+  if [[ "$APPLY_CHANGES" != "true" ]]; then
+    echo "[dry-run] Would close issue #$issue_number"
+    return
+  fi
+
+  gh issue close "$issue_number" --repo "$REPO" --comment "$comment" >/dev/null
+  echo "✅ Closed issue #$issue_number"
+}
+
+delete_issue() {
+  local issue_number="$1"
+
+  if [[ "$APPLY_CHANGES" != "true" ]]; then
+    echo "[dry-run] Would delete issue #$issue_number"
+    return
+  fi
+
+  gh issue delete "$issue_number" --repo "$REPO" --yes >/dev/null
+  echo "🗑️ Deleted issue #$issue_number"
+}
+
+run_resolved_by_pr() {
+  if [[ -z "$PR_NUMBER" ]]; then
+    echo "❌ --pr is required for resolved-by-pr mode"
+    exit 1
+  fi
+
+  local owner repo_name
+  owner="${REPO%%/*}"
+  repo_name="${REPO##*/}"
+
+  local query
+  query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){closingIssuesReferences(first:100){nodes{id number title state labels(first:20){nodes{name}}}}}}}'
+
+  local json
+  json=$(gh api graphql -f query="$query" -F owner="$owner" -F repo="$repo_name" -F number="$PR_NUMBER")
+
+  echo "$json" | jq -c '.data.repository.pullRequest.closingIssuesReferences.nodes[]?' | while read -r issue; do
+    local issue_number issue_title issue_state labels_csv
+    issue_number=$(echo "$issue" | jq -r '.number')
+    issue_title=$(echo "$issue" | jq -r '.title')
+    issue_state=$(echo "$issue" | jq -r '.state')
+    labels_csv=$(echo "$issue" | jq -r '[.labels.nodes[].name] | join(",")')
+
+    if ! is_code_scanning_issue "$issue_title" "$labels_csv"; then
+      continue
+    fi
+
+    if [[ "$issue_state" == "OPEN" ]]; then
+      close_issue "$issue_number" "Closed automatically: resolved by merged PR #$PR_NUMBER."
+    else
+      echo "ℹ️ Issue #$issue_number already closed"
+    fi
+
+    delete_issue "$issue_number"
+  done
+}
+
+extract_alert_id() {
+  local title="$1"
+  local body="$2"
+  local alert_id=""
+
+  alert_id=$(echo "$title" | sed -nE 's/.*[Aa]lert[[:space:]]*#([0-9]+).*/\1/p' | head -n1)
+  if [[ -n "$alert_id" ]]; then
+    echo "$alert_id"
+    return
+  fi
+
+  alert_id=$(echo "$body" | sed -nE 's/.*Code[[:space:]]+Scanning[[:space:]]+Alert[[:space:]]*#([0-9]+).*/\1/p' | head -n1)
+  echo "$alert_id"
+}
+
+run_dedupe_bugs() {
+  local issues_json
+  issues_json=$(gh issue list --repo "$REPO" --state open --label bugs --limit 1000 --json number,title,body,url)
+
+  local tmp_file
+  tmp_file=$(mktemp)
+
+  echo "$issues_json" | jq -c '.[]' | while read -r issue; do
+    local number title body alert_id
+    number=$(echo "$issue" | jq -r '.number')
+    title=$(echo "$issue" | jq -r '.title')
+    body=$(echo "$issue" | jq -r '.body // ""')
+    alert_id=$(extract_alert_id "$title" "$body")
+
+    if [[ -n "$alert_id" ]]; then
+      echo "$alert_id|$number|$title" >> "$tmp_file"
+    fi
+  done
+
+  if [[ ! -s "$tmp_file" ]]; then
+    echo "ℹ️ No bugs issues with detectable alert IDs found."
+    rm -f "$tmp_file"
+    return
+  fi
+
+  cut -d'|' -f1 "$tmp_file" | sort | uniq | while read -r alert_id; do
+    local rows count keeper keeper_number
+    rows=$(grep "^${alert_id}|" "$tmp_file" | sort -t'|' -k2,2n)
+    count=$(echo "$rows" | wc -l | tr -d ' ')
+
+    if [[ "$count" -le 1 ]]; then
+      continue
+    fi
+
+    keeper=$(echo "$rows" | head -n1)
+    keeper_number=$(echo "$keeper" | cut -d'|' -f2)
+    echo "🔁 Alert #$alert_id has $count open issues. Keeping #$keeper_number and removing duplicates."
+
+    echo "$rows" | tail -n +2 | while IFS='|' read -r _ duplicate_number _; do
+      close_issue "$duplicate_number" "Closing duplicate of #$keeper_number for Code Scanning Alert #$alert_id."
+      delete_issue "$duplicate_number"
+    done
+  done
+
+  rm -f "$tmp_file"
+}
+
+parse_args() {
+  shift
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --apply)
+        APPLY_CHANGES="true"
+        shift
+        ;;
+      --pr)
+        PR_NUMBER="${2:-}"
+        shift 2
+        ;;
+      *)
+        echo "❌ Unknown argument: $1"
+        usage
+        exit 1
+        ;;
+    esac
+  done
+}
+
+main() {
+  require_cmd gh
+  require_cmd jq
+
+  case "$MODE" in
+    resolved-by-pr)
+      parse_args "$@"
+      run_resolved_by_pr
+      ;;
+    dedupe-bugs)
+      parse_args "$@"
+      run_dedupe_bugs
+      ;;
+    help|-h|--help)
+      usage
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/tools/run-gitleaks.sh
+++ b/tools/run-gitleaks.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_DIR="$REPO_ROOT/tmp"
+REPORT_FILE="$OUTPUT_DIR/gitleaks-report.json"
+
+mkdir -p "$OUTPUT_DIR"
+
+# Run Gitleaks against the working tree only (no git history).
+# Uses repo config if present.
+gitleaks detect \
+  --source "$REPO_ROOT" \
+  --no-git \
+  --redact \
+  --report-format json \
+  --report-path "$REPORT_FILE"
+
+echo "Gitleaks report written to: $REPORT_FILE"

--- a/tools/seed/README.md
+++ b/tools/seed/README.md
@@ -1,0 +1,121 @@
+# Seeding from NotebookLM Output
+
+## Files
+
+- `tools/seed/starter-data.template.json`: copy this as your starting shape.
+- `tools/seed/starter-data.json`: runtime input (used if no `questions/` directory).
+- `tools/seed/seed-all.mjs`: seed runner.
+- `tools/seed/questions/`: sample question files (auto-loaded if present).
+
+## Quick Start (with Samples)
+
+If you have sample `.json` files in `tools/seed/questions/` (or subdirectories):
+
+```bash
+# Ensure .env.local has:
+# - NEXT_PUBLIC_SUPABASE_URL
+# - SUPABASE_SERVICE_ROLE_KEY
+
+npm run seed
+# or: node tools/seed/seed-all.mjs
+```
+
+The seeder will automatically discover and merge all `.json` files from the `questions/` directory.
+
+During seeding:
+
+- Each successfully inserted question is logged in the terminal.
+- Failed question inserts are written to a timestamped file in `tools/seed/logs/`.
+
+## Manual Seeding (from NotebookLM)
+
+If you don't have sample files yet:
+
+1. Copy template:
+
+```bash
+cp tools/seed/starter-data.template.json tools/seed/starter-data.json
+```
+
+2. Paste/merge transformed NotebookLM content into `tools/seed/starter-data.json`.
+
+3. Ensure `.env.local` contains:
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+
+4. Run seeding:
+
+```bash
+node tools/seed/seed-all.mjs
+```
+
+## How It Works
+
+1. **Sample Loading**: If `tools/seed/questions/` exists, the seeder recursively finds all `.json` files and merges them.
+2. **Deduplication**: Categories, topics, and questions are merged using `slug` and `external_ref` to avoid duplicates.
+3. **Fallback**: If no `questions/` directory, uses `starter-data.json`.
+
+## Expected Seed Order
+
+The script seeds in this order:
+
+1. categories
+2. topics
+3. questions
+
+## Sample File Structure
+
+Each file in `tools/seed/questions/` should follow:
+
+```json
+{
+  "categories": [
+    {
+      "slug": "web-architecture",
+      "name": "Web Architecture",
+      "description": "..."
+    }
+  ],
+  "topics": [
+    {
+      "slug": "rendering-patterns",
+      "name": "Rendering Patterns",
+      "category_slug": "web-architecture",
+      "description": "..."
+    }
+  ],
+  "questions": [
+    {
+      "external_ref": "unique-id-per-source",
+      "question_text": "...",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "...",
+      "hint": "...",
+      "tags": ["tag1", "tag2"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["rendering-patterns"],
+      "category_slugs": ["web-architecture"],
+      "source": {
+        "kind": "video|website|document",
+        "title": "Source Title",
+        "url": "https://...",
+        "section": "Section Name",
+        "timestamp": "HH:MM:SS"
+      },
+      "choices": [
+        { "key": "A", "text": "Option text" }
+      ]
+    }
+  ]
+}
+```
+
+## Validation
+
+After seeding, check:
+
+- `/admin/content/questions`
+- `/admin/content-management`
+- `/admin/learning-cards`

--- a/tools/seed/questions/access-object-js/access-object-js.json
+++ b/tools/seed/questions/access-object-js/access-object-js.json
@@ -1,0 +1,233 @@
+{
+  "categories": [
+    {
+      "slug": "javascript-programming",
+      "name": "JavaScript Programming",
+      "description": "Language specifics, object management, and syntax rules."
+    }
+  ],
+  "topics": [
+    {
+      "slug": "object-property-access",
+      "name": "Object Property Access",
+      "category_slug": "javascript-programming",
+      "description": "Methods for retrieving data from JavaScript objects, including dot, bracket, and destructuring patterns."
+    }
+  ],
+  "questions": [
+    {
+      "external_ref": "pavlutin-identifier-rules-1",
+      "question_text": "Which of the following is a restriction for a property name to be used as a valid identifier with the dot property accessor?",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "An identifier in JavaScript can contain Unicode letters, $, _, and digits 0..9, but it cannot start with a digit.",
+      "hint": "Think about what character cannot be at the very beginning.",
+      "tags": ["syntax", "identifiers"],
+      "learning_modes": ["guided"],
+      "topic_slugs": ["object-property-access"],
+      "category_slugs": ["javascript-programming"],
+      "source": {
+        "kind": "website",
+        "title": "3 Ways To Access Object Properties in JavaScript",
+        "url": null,
+        "section": "1.1 Dot property accessor requires identifiers",
+        "timestamp": null
+      },
+      "choices": [
+        { "key": "A", "text": "It cannot contain the underscore (_) character.", "is_correct": false },
+        { "key": "B", "text": "It cannot start with a digit (0..9).", "is_correct": true },
+        { "key": "C", "text": "It cannot contain Unicode letters.", "is_correct": false },
+        { "key": "D", "text": "It must be at least 3 characters long.", "is_correct": false }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "pavlutin-dot-accessor-failure-analysis",
+      "question_text": "Why does the expression 'weirdObject.prop-3' evaluate to NaN instead of retrieving the property value 'three'?",
+      "question_type": "short_answer",
+      "difficulty": "advanced",
+      "explanation": "Because 'prop-3' is an invalid identifier for dot access, JavaScript interprets the dot as property access to 'prop' (which is undefined) and then attempts to subtract 3 from it, resulting in Not-a-Number (NaN).",
+      "hint": "Consider how JavaScript interprets the hyphen (-) character in this context.",
+      "tags": ["troubleshooting", "syntax"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["object-property-access"],
+      "category_slugs": ["javascript-programming"],
+      "source": {
+        "kind": "website",
+        "title": "3 Ways To Access Object Properties in JavaScript",
+        "url": null,
+        "section": "1.1 Dot property accessor requires identifiers",
+        "timestamp": null
+      },
+      "choices": [],
+      "answer_text": "JavaScript interprets the expression as a subtraction operation (object.prop minus 3) because the hyphen makes it an invalid identifier.",
+      "validation_notes": []
+    },
+    {
+      "external_ref": "pavlutin-bracket-syntax-rule",
+      "question_text": "In the square brackets property accessor syntax 'expression[expression]', what must the second expression evaluate to?",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "The first expression evaluates to the object, and the second expression must evaluate to a string that denotes the property name.",
+      "hint": "Property names are ultimately treated as what data type?",
+      "tags": ["syntax", "basics"],
+      "learning_modes": ["guided"],
+      "topic_slugs": ["object-property-access"],
+      "category_slugs": ["javascript-programming"],
+      "source": {
+        "kind": "website",
+        "title": "3 Ways To Access Object Properties in JavaScript",
+        "url": null,
+        "section": "2. Square brackets property accessor",
+        "timestamp": null
+      },
+      "choices": [
+        { "key": "A", "text": "A boolean value.", "is_correct": false },
+        { "key": "B", "text": "A string denoting the property name.", "is_correct": true },
+        { "key": "C", "text": "A mathematical formula.", "is_correct": false },
+        { "key": "D", "text": "A reference to the window object.", "is_correct": false }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "pavlutin-destructuring-alias-syntax",
+      "question_text": "What is the correct syntax to extract a property into a variable with a different name (aliasing) using destructuring?",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "The syntax 'const { identifier: aliasIdentifier } = expression' allows you to map the property name to a new variable name.",
+      "hint": "The colon separates the property name from the new variable name.",
+      "tags": ["destructuring", "aliasing"],
+      "learning_modes": ["guided", "custom"],
+      "topic_slugs": ["object-property-access"],
+      "category_slugs": ["javascript-programming"],
+      "source": {
+        "kind": "website",
+        "title": "3 Ways To Access Object Properties in JavaScript",
+        "url": null,
+        "section": "3.1 Alias variable",
+        "timestamp": null
+      },
+      "choices": [
+        { "key": "A", "text": "const { property as alias } = object", "is_correct": false },
+        { "key": "B", "text": "const { property: alias } = object", "is_correct": true },
+        { "key": "C", "text": "const { alias = property } = object", "is_correct": false },
+        { "key": "D", "text": "const { property -> alias } = object", "is_correct": false }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "pavlutin-dynamic-destructuring-syntax",
+      "question_text": "Which syntax is used to perform object destructuring when the property name is dynamic and determined at runtime?",
+      "question_type": "mcq",
+      "difficulty": "advanced",
+      "explanation": "To destructure a dynamic property, you must wrap the expression in square brackets inside the destructuring pattern: { [expression]: identifier }.",
+      "hint": "It combines square bracket logic inside the destructuring braces.",
+      "tags": ["destructuring", "dynamic-programming"],
+      "learning_modes": ["guided", "custom"],
+      "topic_slugs": ["object-property-access"],
+      "category_slugs": ["javascript-programming"],
+      "source": {
+        "kind": "website",
+        "title": "3 Ways To Access Object Properties in JavaScript",
+        "url": null,
+        "section": "3.2 Dynamic property name",
+        "timestamp": null
+      },
+      "choices": [
+        { "key": "A", "text": "const { property } = object", "is_correct": false },
+        { "key": "B", "text": "const { [property]: variable } = object", "is_correct": true },
+        { "key": "C", "text": "const { .property: variable } = object", "is_correct": false },
+        { "key": "D", "text": "const { property(variable) } = object", "is_correct": false }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "pavlutin-missing-property-result",
+      "question_text": "True or False: In JavaScript, if you attempt to access a property that does not exist using any of the three accessor syntaxes, the code will throw a ReferenceError.",
+      "question_type": "true_false",
+      "difficulty": "beginner",
+      "explanation": "If the accessed property doesn't exist, all 3 accessor syntaxes (dot, brackets, and destructuring) simply evaluate to 'undefined', they do not throw an error.",
+      "hint": "Think about the standard value for 'nothing found' in an object.",
+      "tags": ["error-handling", "fundamentals"],
+      "learning_modes": ["guided"],
+      "topic_slugs": ["object-property-access"],
+      "category_slugs": ["javascript-programming"],
+      "source": {
+        "kind": "website",
+        "title": "3 Ways To Access Object Properties in JavaScript",
+        "url": null,
+        "section": "4. When the property doesn't exist",
+        "timestamp": null
+      },
+      "choices": [
+        { "key": "A", "text": "True", "is_correct": false },
+        { "key": "B", "text": "False", "is_correct": true }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    }
+  ],
+  "learning_cards": [
+    {
+      "external_ref": "pavlutin-card-dot-vs-bracket",
+      "title": "Dot vs Bracket Access",
+      "front": "When should you choose square brackets over the dot property accessor?",
+      "back": "When the property name is dynamic (determined at runtime) or when the property name is not a valid identifier (e.g., starts with a digit or contains a hyphen).",
+      "difficulty": "beginner",
+      "topic_slugs": ["object-property-access"],
+      "category_slugs": ["javascript-programming"],
+      "learning_modes": ["guided"],
+      "source": {
+        "kind": "website",
+        "title": "3 Ways To Access Object Properties in JavaScript",
+        "url": null,
+        "section": "5. Conclusion",
+        "timestamp": null
+      },
+      "validation_notes": []
+    },
+    {
+      "external_ref": "pavlutin-card-destructuring-use",
+      "title": "Purpose of Destructuring",
+      "front": "When is it most appropriate to use object destructuring for property access?",
+      "back": "When you want to extract a property value directly into a standalone variable.",
+      "difficulty": "beginner",
+      "topic_slugs": ["object-property-access"],
+      "category_slugs": ["javascript-programming"],
+      "learning_modes": ["guided"],
+      "source": {
+        "kind": "website",
+        "title": "3 Ways To Access Object Properties in JavaScript",
+        "url": null,
+        "section": "3. Object destructuring",
+        "timestamp": null
+      },
+      "validation_notes": []
+    }
+  ],
+  "relations": {
+    "questions_topics": [
+      { "question_external_ref": "pavlutin-identifier-rules-1", "topic_slug": "object-property-access" },
+      { "question_external_ref": "pavlutin-dot-accessor-failure-analysis", "topic_slug": "object-property-access" },
+      { "question_external_ref": "pavlutin-bracket-syntax-rule", "topic_slug": "object-property-access" },
+      { "question_external_ref": "pavlutin-destructuring-alias-syntax", "topic_slug": "object-property-access" },
+      { "question_external_ref": "pavlutin-dynamic-destructuring-syntax", "topic_slug": "object-property-access" },
+      { "question_external_ref": "pavlutin-missing-property-result", "topic_slug": "object-property-access" }
+    ],
+    "card_categories": [
+      { "card_external_ref": "pavlutin-card-dot-vs-bracket", "category_slug": "javascript-programming" },
+      { "card_external_ref": "pavlutin-card-destructuring-use", "category_slug": "javascript-programming" }
+    ],
+    "plan_questions": []
+  },
+  "quality_report": {
+    "total_sources_used": 1,
+    "total_questions_extracted": 6,
+    "duplicates_removed": 1,
+    "low_confidence_items": []
+  }
+}

--- a/tools/seed/questions/async-defer/async-defer.json
+++ b/tools/seed/questions/async-defer/async-defer.json
@@ -1,0 +1,202 @@
+{
+  "categories": [
+    {
+      "slug": "web-performance",
+      "name": "Web Performance",
+      "description": "Strategies for optimizing browser loading sequences and resource execution."
+    }
+  ],
+  "topics": [
+    {
+      "slug": "script-loading-strategies",
+      "name": "Script Loading Strategies",
+      "category_slug": "web-performance",
+      "description": "Techniques for managing external JavaScript via async, defer, and traditional tag placement."
+    }
+  ],
+  "questions": [
+    {
+      "external_ref": "mathew-traditional-script-block",
+      "question_text": "What is the primary performance disadvantage of placing traditional <script> tags in the <head> section of an HTML document?",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "Placing scripts in the head section blocks HTML parsing until the JavaScript file is both fetched and executed, which slows down the overall page load time.",
+      "hint": "Think about what happens to the HTML parser while the script is being handled.",
+      "tags": ["performance", "parsing"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["script-loading-strategies"],
+      "category_slugs": ["web-performance"],
+      "source": {
+        "kind": "website",
+        "title": "Async vs Defer in JavaScript: Which is Better?🤔",
+        "url": null,
+        "section": "Default Behaviour",
+        "timestamp": null
+      },
+      "choices": [
+        { "key": "A", "text": "The script will fail to download in most browsers.", "is_correct": false },
+        { "key": "B", "text": "The browser blocks HTML parsing until the script is fetched and executed.", "is_correct": true },
+        { "key": "C", "text": "The script executes before the CSS is loaded.", "is_correct": false },
+        { "key": "D", "text": "It forces the script to execute twice.", "is_correct": false }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "mathew-async-execution-order",
+      "question_text": "How does the 'async' attribute determine the execution order of multiple scripts?",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Scripts with the 'async' attribute execute as soon as they finish downloading, regardless of their order in the HTML document.",
+      "hint": "Does it respect the order in the code or the order of completion?",
+      "tags": ["async", "execution-order"],
+      "learning_modes": ["guided"],
+      "topic_slugs": ["script-loading-strategies"],
+      "category_slugs": ["web-performance"],
+      "source": {
+        "kind": "website",
+        "title": "Async vs Defer in JavaScript: Which is Better?🤔",
+        "url": null,
+        "section": "Async",
+        "timestamp": null
+      },
+      "choices": [
+        { "key": "A", "text": "They execute in the exact order they appear in the document.", "is_correct": false },
+        { "key": "B", "text": "They execute only after the entire DOM is parsed.", "is_correct": false },
+        { "key": "C", "text": "They execute as soon as they finish downloading.", "is_correct": true },
+        { "key": "D", "text": "They execute simultaneously using multi-threading.", "is_correct": false }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "mathew-defer-lifecycle-timing",
+      "question_text": "At what specific point in the page lifecycle do scripts with the 'defer' attribute execute?",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Scripts with the 'defer' attribute execute after the HTML document has been fully parsed, but before the DOMContentLoaded event fires.",
+      "hint": "It happens after parsing but before a major DOM event.",
+      "tags": ["defer", "lifecycle"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["script-loading-strategies"],
+      "category_slugs": ["web-performance"],
+      "source": {
+        "kind": "website",
+        "title": "Async vs Defer in JavaScript: Which is Better?🤔",
+        "url": null,
+        "section": "Conclusion",
+        "timestamp": null
+      },
+      "choices": [
+        { "key": "A", "text": "Immediately after the script finishes downloading.", "is_correct": false },
+        { "key": "B", "text": "After the window.onload event has fired.", "is_correct": false },
+        { "key": "C", "text": "After HTML parsing is finished but before DOMContentLoaded.", "is_correct": true },
+        { "key": "D", "text": "Directly before the HTML starts parsing.", "is_correct": false }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "mathew-async-vs-defer-decision",
+      "question_text": "What is the recommended criteria for choosing the 'async' attribute over 'defer' for a script?",
+      "question_type": "short_answer",
+      "difficulty": "intermediate",
+      "explanation": "Async should be used for scripts that can run independently, do not rely on the DOM structure, and do not depend on other scripts.",
+      "hint": "Consider the script's dependencies.",
+      "tags": ["best-practices", "decision-making"],
+      "learning_modes": ["guided", "custom"],
+      "topic_slugs": ["script-loading-strategies"],
+      "category_slugs": ["web-performance"],
+      "source": {
+        "kind": "website",
+        "title": "Async vs Defer in JavaScript: Which is Better?🤔",
+        "url": null,
+        "section": "Conclusion",
+        "timestamp": null
+      },
+      "choices": [],
+      "answer_text": "Use async when scripts are independent, do not rely on the DOM structure, and do not have execution order dependencies with other scripts.",
+      "validation_notes": []
+    },
+    {
+      "external_ref": "engelman-web-component-loading",
+      "question_text": "According to the discussion on Web Components, why might using 'async' or 'defer' be problematic for native connectedCallback execution?",
+      "question_type": "short_answer",
+      "difficulty": "advanced",
+      "explanation": "In native Web Components, the connectedCallback fires on the opening tag. Using async or defer can delay the definition of the component until after the tag is encountered, which may lead to issues if the component needs to be defined before parsing.",
+      "hint": "Focus on the timing of custom element definition versus DOM parsing.",
+      "tags": ["web-components", "advanced"],
+      "learning_modes": ["custom"],
+      "topic_slugs": ["script-loading-strategies"],
+      "category_slugs": ["web-performance"],
+      "source": {
+        "kind": "website",
+        "title": "Async vs Defer in JavaScript: Which is Better?🤔",
+        "url": null,
+        "section": "Top comments",
+        "timestamp": null
+      },
+      "choices": [],
+      "answer_text": "Because the native connectedCallback fires on the opening tag, and delaying script execution via async/defer may prevent the component from being defined before the browser parses that tag.",
+      "validation_notes": []
+    }
+  ],
+  "learning_cards": [
+    {
+      "external_ref": "mathew-card-defer-order",
+      "title": "Defer Execution Order",
+      "front": "How is execution order handled for multiple scripts using the 'defer' attribute?",
+      "back": "Scripts with the defer attribute are guaranteed to execute in the exact order they appear in the HTML document.",
+      "difficulty": "beginner",
+      "topic_slugs": ["script-loading-strategies"],
+      "category_slugs": ["web-performance"],
+      "learning_modes": ["guided"],
+      "source": {
+        "kind": "website",
+        "title": "Async vs Defer in JavaScript: Which is Better?🤔",
+        "url": null,
+        "section": "Defer",
+        "timestamp": null
+      },
+      "validation_notes": []
+    },
+    {
+      "external_ref": "mathew-card-async-parsing",
+      "title": "Async and Parsing",
+      "front": "Does a script with the 'async' attribute block HTML parsing during its download?",
+      "back": "No. The script is downloaded in the background asynchronously without blocking the HTML parsing process.",
+      "difficulty": "beginner",
+      "topic_slugs": ["script-loading-strategies"],
+      "category_slugs": ["web-performance"],
+      "learning_modes": ["guided"],
+      "source": {
+        "kind": "website",
+        "title": "Async vs Defer in JavaScript: Which is Better?🤔",
+        "url": null,
+        "section": "Async",
+        "timestamp": null
+      },
+      "validation_notes": []
+    }
+  ],
+  "relations": {
+    "questions_topics": [
+      { "question_external_ref": "mathew-traditional-script-block", "topic_slug": "script-loading-strategies" },
+      { "question_external_ref": "mathew-async-execution-order", "topic_slug": "script-loading-strategies" },
+      { "question_external_ref": "mathew-defer-lifecycle-timing", "topic_slug": "script-loading-strategies" },
+      { "question_external_ref": "mathew-async-vs-defer-decision", "topic_slug": "script-loading-strategies" },
+      { "question_external_ref": "engelman-web-component-loading", "topic_slug": "script-loading-strategies" }
+    ],
+    "card_categories": [
+      { "card_external_ref": "mathew-card-defer-order", "category_slug": "web-performance" },
+      { "card_external_ref": "mathew-card-async-parsing", "category_slug": "web-performance" }
+    ],
+    "plan_questions": []
+  },
+  "quality_report": {
+    "total_sources_used": 1,
+    "total_questions_extracted": 5,
+    "duplicates_removed": 0,
+    "low_confidence_items": []
+  }
+}

--- a/tools/seed/questions/event-propagation/event-propagation.json
+++ b/tools/seed/questions/event-propagation/event-propagation.json
@@ -1,0 +1,186 @@
+{
+  "categories": [
+    {
+      "slug": "javascript-programming",
+      "name": "JavaScript Programming",
+      "description": "Language specifics, DOM interaction, and event handling."
+    }
+  ],
+  "topics": [
+    {
+      "slug": "event-propagation",
+      "name": "Event Propagation",
+      "category_slug": "javascript-programming",
+      "description": "The mechanism of how events travel through nested DOM elements."
+    }
+  ],
+  "questions": [
+    {
+      "external_ref": "wilkie-bubbling-definition",
+      "question_text": "What is the term for the default behavior where an event moves from the most-nested element 'up' to the least-nested element (like the document)?",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "The movement of events from the inner-most element to the outer-most container (document) is referred to as 'bubbling'.",
+      "hint": "Think of air rising in water.",
+      "tags": ["dom", "events", "bubbling"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["event-propagation"],
+      "category_slugs": ["javascript-programming"],
+      "source": {
+        "kind": "document",
+        "title": "A simplified explanation of event propagation in JavaScript.",
+        "url": null,
+        "section": "Bubbles",
+        "timestamp": null
+      },
+      "choices": [
+        { "key": "A", "text": "Trickling", "is_correct": false },
+        { "key": "B", "text": "Capturing", "is_correct": false },
+        { "key": "C", "text": "Bubbling", "is_correct": true },
+        { "key": "D", "text": "Tunneling", "is_correct": false }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "wilkie-trickling-definition",
+      "question_text": "If events start in the 'outer-most' element and move 'down' to the most-nested element, what is this process called?",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "According to the source, when events move from the outer container down to the nested target, it is referred to as 'trickling'.",
+      "hint": "It is the opposite of bubbling.",
+      "tags": ["dom", "events", "trickling"],
+      "learning_modes": ["guided"],
+      "topic_slugs": ["event-propagation"],
+      "category_slugs": ["javascript-programming"],
+      "source": {
+        "kind": "document",
+        "title": "A simplified explanation of event propagation in JavaScript.",
+        "url": null,
+        "section": "Bubbles",
+        "timestamp": null
+      },
+      "choices": [
+        { "key": "A", "text": "Bubbling", "is_correct": false },
+        { "key": "B", "text": "Trickling", "is_correct": true },
+        { "key": "C", "text": "Hoisting", "is_correct": false },
+        { "key": "D", "text": "Propagation", "is_correct": false }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "wilkie-stop-propagation-method",
+      "question_text": "Which JavaScript method is used to halt the bubbling of events up through the DOM?",
+      "question_type": "short_answer",
+      "difficulty": "beginner",
+      "explanation": "The 'e.stopPropagation()' method halts the bubbling process, preventing the event from firing on parent elements in the stack.",
+      "hint": "The method name describes exactly what it does to propagation.",
+      "tags": ["dom", "methods", "bubbling"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["event-propagation"],
+      "category_slugs": ["javascript-programming"],
+      "source": {
+        "kind": "document",
+        "title": "A simplified explanation of event propagation in JavaScript.",
+        "url": null,
+        "section": "How to use event propagation to your advantage",
+        "timestamp": null
+      },
+      "choices": [],
+      "answer_text": "e.stopPropagation()",
+      "validation_notes": []
+    },
+    {
+      "external_ref": "wilkie-propagation-nesting-logic",
+      "question_text": "True or False: Because elements on a web browser are nested rather than covering each other up, a click on a nested 'a' tag also clicks on its parent row, the table, and the document.",
+      "question_type": "true_false",
+      "difficulty": "intermediate",
+      "explanation": "Elements do not cover each other; they are nested. Therefore, a click on a child element is also technically a click on all its parent containers all the way to the document.",
+      "hint": "Think about the stack of elements being clicked simultaneously.",
+      "tags": ["dom", "logic"],
+      "learning_modes": ["guided"],
+      "topic_slugs": ["event-propagation"],
+      "category_slugs": ["javascript-programming"],
+      "source": {
+        "kind": "document",
+        "title": "A simplified explanation of event propagation in JavaScript.",
+        "url": null,
+        "section": "Event propagation in a nutshell",
+        "timestamp": null
+      },
+      "choices": [
+        { "key": "A", "text": "True", "is_correct": true },
+        { "key": "B", "text": "False", "is_correct": false }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "wilkie-preventdefault-vs-stoppropagation",
+      "question_text": "Why might 'e.preventDefault()' fail to stop a parent element's onClick event from firing when a child element is clicked?",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "preventDefault() only stops the default browser behavior (like a form refreshing or a link navigating). It does not stop the event from bubbling up the DOM stack to parent elements.",
+      "hint": "Distinguish between 'browser default action' and 'event bubbling'.",
+      "tags": ["dom", "methods", "troubleshooting"],
+      "learning_modes": ["guided", "custom"],
+      "topic_slugs": ["event-propagation"],
+      "category_slugs": ["javascript-programming"],
+      "source": {
+        "kind": "document",
+        "title": "A simplified explanation of event propagation in JavaScript.",
+        "url": null,
+        "section": "preventDefault vs. stopPropagation",
+        "timestamp": null
+      },
+      "choices": [
+        { "key": "A", "text": "Because it is only compatible with form elements.", "is_correct": false },
+        { "key": "B", "text": "Because it stops the event from reaching the document but not the immediate parent.", "is_correct": false },
+        { "key": "C", "text": "Because it handles default browser actions rather than the event propagation stack.", "is_correct": true },
+        { "key": "D", "text": "Because it can only be used in React, not plain JavaScript.", "is_correct": false }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    }
+  ],
+  "learning_cards": [
+    {
+      "external_ref": "wilkie-card-bubbling-path",
+      "title": "Event Bubbling Path",
+      "front": "Where does event bubbling eventually end if it is not stopped?",
+      "back": "It moves all the way out to the 'document', the complete container that holds everything in the browser.",
+      "difficulty": "beginner",
+      "topic_slugs": ["event-propagation"],
+      "category_slugs": ["javascript-programming"],
+      "learning_modes": ["guided"],
+      "source": {
+        "kind": "document",
+        "title": "A simplified explanation of event propagation in JavaScript.",
+        "url": null,
+        "section": "Event propagation in a nutshell",
+        "timestamp": null
+      },
+      "validation_notes": []
+    }
+  ],
+  "relations": {
+    "questions_topics": [
+      { "question_external_ref": "wilkie-bubbling-definition", "topic_slug": "event-propagation" },
+      { "question_external_ref": "wilkie-trickling-definition", "topic_slug": "event-propagation" },
+      { "question_external_ref": "wilkie-stop-propagation-method", "topic_slug": "event-propagation" },
+      { "question_external_ref": "wilkie-propagation-nesting-logic", "topic_slug": "event-propagation" },
+      { "question_external_ref": "wilkie-preventdefault-vs-stoppropagation", "topic_slug": "event-propagation" }
+    ],
+    "card_categories": [
+      { "card_external_ref": "wilkie-card-bubbling-path", "category_slug": "javascript-programming" }
+    ],
+    "plan_questions": []
+  },
+  "quality_report": {
+    "total_sources_used": 1,
+    "total_questions_extracted": 5,
+    "duplicates_removed": 0,
+    "low_confidence_items": []
+  }
+}

--- a/tools/seed/questions/javascript/javascript.json
+++ b/tools/seed/questions/javascript/javascript.json
@@ -1,0 +1,5854 @@
+{
+  "categories": [
+    {
+      "slug": "javascript-core-concepts",
+      "name": "JavaScript Core Concepts",
+      "description": "Fundamental concepts of the JavaScript programming language, including data types, functions, and execution context."
+    },
+    {
+      "slug": "objects-and-functions",
+      "name": "Objects and Functions",
+      "description": "Working with objects, functions, prototypes, and classes in JavaScript."
+    },
+    {
+      "slug": "async-javascript",
+      "name": "Asynchronous JavaScript",
+      "description": "Managing asynchronous operations with promises, async/await, and event loop."
+    },
+    {
+      "slug": "es6-features",
+      "name": "ES6+ Features",
+      "description": "Modern JavaScript features including destructuring, spread operators, and new data structures."
+    },
+    {
+      "slug": "javascript-methods",
+      "name": "JavaScript Methods",
+      "description": "Built-in methods for arrays, objects, strings, and other JavaScript data types."
+    },
+    {
+      "slug": "error-and-debugging",
+      "name": "Error Handling and Debugging",
+      "description": "Understanding errors, debugging techniques, and error handling in JavaScript."
+    },
+    {
+      "slug": "browser-apis",
+      "name": "Browser APIs",
+      "description": "Web APIs available in the browser environment including DOM, storage, and timers."
+    }
+  ],
+  "topics": [
+    {
+      "slug": "hoisting",
+      "name": "Hoisting",
+      "category_slug": "javascript-core-concepts",
+      "description": "JavaScript's behavior of moving declarations to the top of their scope during compilation."
+    },
+    {
+      "slug": "scope",
+      "name": "Scope and Closures",
+      "category_slug": "javascript-core-concepts",
+      "description": "Variable accessibility and function scope in JavaScript."
+    },
+    {
+      "slug": "type-coercion",
+      "name": "Type Coercion",
+      "category_slug": "javascript-core-concepts",
+      "description": "Automatic or implicit conversion of values from one data type to another."
+    },
+    {
+      "slug": "equality-comparison",
+      "name": "Equality and Comparisons",
+      "category_slug": "javascript-core-concepts",
+      "description": "Understanding equality operators (== vs ===) and value comparison."
+    },
+    {
+      "slug": "data-types",
+      "name": "Data Types and Structures",
+      "category_slug": "javascript-core-concepts",
+      "description": "Primitive and reference data types in JavaScript."
+    },
+    {
+      "slug": "this-keyword",
+      "name": "'this' Keyword",
+      "category_slug": "objects-and-functions",
+      "description": "Understanding the behavior of the 'this' keyword in different contexts."
+    },
+    {
+      "slug": "prototypes",
+      "name": "Prototypes and Inheritance",
+      "category_slug": "objects-and-functions",
+      "description": "JavaScript's prototypal inheritance model."
+    },
+    {
+      "slug": "functions",
+      "name": "Functions and Methods",
+      "category_slug": "objects-and-functions",
+      "description": "Different types of functions including regular, arrow, and generator functions."
+    },
+    {
+      "slug": "classes",
+      "name": "Classes and OOP",
+      "category_slug": "objects-and-functions",
+      "description": "ES6 class syntax and object-oriented programming in JavaScript."
+    },
+    {
+      "slug": "objects",
+      "name": "Object Manipulation",
+      "category_slug": "objects-and-functions",
+      "description": "Creating, modifying, and working with JavaScript objects."
+    },
+    {
+      "slug": "event-loop",
+      "name": "Event Loop and Concurrency",
+      "category_slug": "async-javascript",
+      "description": "Understanding JavaScript's event loop, call stack, and task queues."
+    },
+    {
+      "slug": "promises",
+      "name": "Promises",
+      "category_slug": "async-javascript",
+      "description": "Working with promises for asynchronous operations."
+    },
+    {
+      "slug": "async-await",
+      "name": "Async/Await",
+      "category_slug": "async-javascript",
+      "description": "Modern syntax for handling asynchronous code."
+    },
+    {
+      "slug": "timers",
+      "name": "Timers and Intervals",
+      "category_slug": "async-javascript",
+      "description": "Working with setTimeout, setInterval, and scheduling."
+    },
+    {
+      "slug": "destructuring",
+      "name": "Destructuring",
+      "category_slug": "es6-features",
+      "description": "Extracting data from arrays and objects using destructuring syntax."
+    },
+    {
+      "slug": "spread-rest",
+      "name": "Spread and Rest Operators",
+      "category_slug": "es6-features",
+      "description": "Using spread and rest operators for array and object manipulation."
+    },
+    {
+      "slug": "symbols",
+      "name": "Symbols and Unique Identifiers",
+      "category_slug": "es6-features",
+      "description": "Using Symbol primitive type for unique property keys."
+    },
+    {
+      "slug": "maps-sets",
+      "name": "Map and Set",
+      "category_slug": "es6-features",
+      "description": "ES6 collection data structures."
+    },
+    {
+      "slug": "array-methods",
+      "name": "Array Methods",
+      "category_slug": "javascript-methods",
+      "description": "Built-in methods for array manipulation."
+    },
+    {
+      "slug": "string-methods",
+      "name": "String Methods",
+      "category_slug": "javascript-methods",
+      "description": "Built-in methods for string manipulation."
+    },
+    {
+      "slug": "object-methods",
+      "name": "Object Methods",
+      "category_slug": "javascript-methods",
+      "description": "Built-in methods for object manipulation."
+    },
+    {
+      "slug": "json",
+      "name": "JSON Methods",
+      "category_slug": "javascript-methods",
+      "description": "Working with JSON parsing and stringification."
+    },
+    {
+      "slug": "error-handling",
+      "name": "Error Handling",
+      "category_slug": "error-and-debugging",
+      "description": "Try/catch blocks and error management."
+    },
+    {
+      "slug": "strict-mode",
+      "name": "Strict Mode",
+      "category_slug": "error-and-debugging",
+      "description": "JavaScript's strict mode and its implications."
+    },
+    {
+      "slug": "storage-apis",
+      "name": "Storage APIs",
+      "category_slug": "browser-apis",
+      "description": "Browser storage mechanisms including sessionStorage and localStorage."
+    },
+    {
+      "slug": "dom-events",
+      "name": "DOM Events",
+      "category_slug": "browser-apis",
+      "description": "Event handling and propagation in the browser."
+    },
+    {
+      "slug": "modules",
+      "name": "Modules and Imports",
+      "category_slug": "javascript-core-concepts",
+      "description": "ES6 module system and import/export syntax."
+    }
+  ],
+  "questions": [
+    {
+      "external_ref": "js-question-001",
+      "question_text": "What is the output of the following code?\n\n```javascript\nfunction sayHi() {\n  console.log(name);\n  console.log(age);\n  var name = 'Lydia';\n  let age = 21;\n}\n\nsayHi();\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Variables declared with var are hoisted and initialized with undefined, while variables declared with let are hoisted but not initialized (temporal dead zone), causing a ReferenceError when accessed before declaration.",
+      "hint": "Consider the difference between var and let hoisting behavior.",
+      "tags": ["hoisting", "var", "let", "temporal-dead-zone", "scope"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["hoisting", "scope"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 1",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "Lydia and undefined",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "Lydia and ReferenceError",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "ReferenceError and 21",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "undefined and ReferenceError",
+          "is_correct": true
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-002",
+      "question_text": "What is the output of the following code?\n\n```javascript\nfor (var i = 0; i < 3; i++) {\n  setTimeout(() => console.log(i), 1);\n}\n\nfor (let i = 0; i < 3; i++) {\n  setTimeout(() => console.log(i), 1);\n}\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "var is function-scoped, so the same i is shared across all setTimeout callbacks, logging 3 three times. let is block-scoped, creating a new i for each iteration, logging 0, 1, 2.",
+      "hint": "Consider the scope differences between var and let in loops.",
+      "tags": ["scope", "var", "let", "settimeout", "event-loop", "closures"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["scope", "event-loop", "timers"],
+      "category_slugs": ["javascript-core-concepts", "async-javascript"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 2",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "0 1 2 and 0 1 2",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "0 1 2 and 3 3 3",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "3 3 3 and 0 1 2",
+          "is_correct": true
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-003",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst shape = {\n  radius: 10,\n  diameter() {\n    return this.radius * 2;\n  },\n  perimeter: () => 2 * Math.PI * this.radius,\n};\n\nconsole.log(shape.diameter());\nconsole.log(shape.perimeter());\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Regular functions have their own 'this' binding (referring to the object). Arrow functions inherit 'this' from the surrounding scope (global/window), where radius is undefined, resulting in NaN when used in calculations.",
+      "hint": "Examine how 'this' behaves differently in regular functions versus arrow functions.",
+      "tags": ["this", "arrow-functions", "object-methods"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["this-keyword", "functions", "objects"],
+      "category_slugs": ["objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 3",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "20 and 62.83185307179586",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "20 and NaN",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "20 and 63",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "NaN and 63",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-004",
+      "question_text": "What is the output of the following code?\n\n```javascript\n+true;\n!'Lydia';\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "The unary plus converts true to 1. The logical NOT operator converts the truthy string 'Lydia' to false when checking if it's falsy.",
+      "hint": "Understand how unary operators convert types.",
+      "tags": ["type-coercion", "unary-operators", "truthy-falsy"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["type-coercion", "data-types"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 4",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "1 and false",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "false and NaN",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "false and false",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-005",
+      "question_text": "Given the following objects, which statement is NOT valid?\n\n```javascript\nconst bird = {\n  size: 'small',\n};\n\nconst mouse = {\n  name: 'Mickey',\n  small: true,\n};\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "mouse.bird.size attempts to access the 'size' property of undefined (mouse.bird is undefined). Bracket notation evaluates expressions first: mouse[bird.size] becomes mouse['small'], which returns true.",
+      "hint": "Distinguish between dot notation and bracket notation for object property access.",
+      "tags": ["objects", "property-access", "dot-notation", "bracket-notation"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["objects"],
+      "category_slugs": ["objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 5",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "mouse.bird.size is not valid",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "mouse[bird.size] is not valid",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "mouse[bird[\"size\"]] is not valid",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "All of them are valid",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-006",
+      "question_text": "What is the output of the following code?\n\n```javascript\nlet c = { greeting: 'Hey!' };\nlet d;\n\nd = c;\nc.greeting = 'Hello';\nconsole.log(d.greeting);\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "Objects are assigned by reference. When d = c, both variables point to the same object in memory. Modifying the object through one reference affects the other.",
+      "hint": "Consider how objects are stored and referenced in JavaScript.",
+      "tags": ["objects", "references", "assignment"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["objects", "data-types"],
+      "category_slugs": ["objects-and-functions", "javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 6",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "Hello",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "Hey!",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "undefined",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "ReferenceError",
+          "is_correct": false
+        },
+        {
+          "key": "E",
+          "text": "TypeError",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-007",
+      "question_text": "What is the output of the following code?\n\n```javascript\nlet a = 3;\nlet b = new Number(3);\nlet c = 3;\n\nconsole.log(a == b);\nconsole.log(a === b);\nconsole.log(b === c);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "new Number(3) creates an object wrapper, not a primitive number. == checks value equality after type coercion (true), while === checks both value and type (false). Both a === b and b === c are false because b is an object, not a number primitive.",
+      "hint": "Understand the difference between primitive values and object wrappers.",
+      "tags": ["type-coercion", "equality", "objects", "number"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["equality-comparison", "data-types", "type-coercion"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 7",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "true false true",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "false false true",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "true false false",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "false true true",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-008",
+      "question_text": "What is the output of the following code?\n\n```javascript\nclass Chameleon {\n  static colorChange(newColor) {\n    this.newColor = newColor;\n    return this.newColor;\n  }\n\n  constructor({ newColor = 'green' } = {}) {\n    this.newColor = newColor;\n  }\n}\n\nconst freddie = new Chameleon({ newColor: 'purple' });\nconsole.log(freddie.colorChange('orange'));\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Static methods are defined on the class itself, not on instances. They cannot be called on instances (freddie), only on the class (Chameleon.colorChange()).",
+      "hint": "Review the purpose and usage of static methods in classes.",
+      "tags": ["classes", "static-methods", "oop"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["classes"],
+      "category_slugs": ["objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 8",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "orange",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "purple",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "green",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "TypeError",
+          "is_correct": true
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-009",
+      "question_text": "What is the output of the following code?\n\n```javascript\nlet greeting;\ngreetign = {}; // Typo!\nconsole.log(greetign);\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "Due to the typo, 'greetign' becomes a property on the global object (window in browsers, global in Node.js). This creates an empty object on the global scope.",
+      "hint": "Consider what happens when you assign to an undeclared variable.",
+      "tags": ["global-object", "variables", "strict-mode"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["scope", "strict-mode"],
+      "category_slugs": ["javascript-core-concepts", "error-and-debugging"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 9",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "{}",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "ReferenceError: greetign is not defined",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "undefined",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-010",
+      "question_text": "What happens when we run this code?\n\n```javascript\nfunction bark() {\n  console.log('Woof!');\n}\n\nbark.animal = 'dog';\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "Functions are objects in JavaScript. They can have properties added to them just like any other object.",
+      "hint": "Think about what type functions are in JavaScript.",
+      "tags": ["functions", "objects", "properties"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["functions", "objects"],
+      "category_slugs": ["objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 10",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "Nothing, this is totally fine!",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "SyntaxError. You cannot add properties to a function this way.",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "\"Woof\" gets logged.",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "ReferenceError",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-011",
+      "question_text": "What is the output of the following code?\n\n```javascript\nfunction Person(firstName, lastName) {\n  this.firstName = firstName;\n  this.lastName = lastName;\n}\n\nconst member = new Person('Lydia', 'Hallie');\nPerson.getFullName = function() {\n  return `${this.firstName} ${this.lastName}`;\n};\n\nconsole.log(member.getFullName());\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "The getFullName method is added to the constructor function itself, not to its prototype. Instance methods must be added to the prototype to be accessible to instances.",
+      "hint": "Consider the difference between adding methods to a constructor vs. its prototype.",
+      "tags": ["prototypes", "constructors", "methods", "inheritance"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["prototypes", "functions", "classes"],
+      "category_slugs": ["objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 11",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "TypeError",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "SyntaxError",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "Lydia Hallie",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "undefined undefined",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-012",
+      "question_text": "What is the output of the following code?\n\n```javascript\nfunction Person(firstName, lastName) {\n  this.firstName = firstName;\n  this.lastName = lastName;\n}\n\nconst lydia = new Person('Lydia', 'Hallie');\nconst sarah = Person('Sarah', 'Smith');\n\nconsole.log(lydia);\nconsole.log(sarah);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "When called with new, this refers to the new object. Without new, this refers to the global object, and the function doesn't return anything, so sarah is undefined.",
+      "hint": "Understand what happens when you forget the 'new' keyword with constructor functions.",
+      "tags": ["constructors", "new-keyword", "this"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["this-keyword", "functions", "objects"],
+      "category_slugs": ["objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 12",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "Person {firstName: \"Lydia\", lastName: \"Hallie\"} and undefined",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "Person {firstName: \"Lydia\", lastName: \"Hallie\"} and Person {firstName: \"Sarah\", lastName: \"Smith\"}",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "Person {firstName: \"Lydia\", lastName: \"Hallie\"} and {}",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "Person {firstName: \"Lydia\", lastName: \"Hallie\"} and ReferenceError",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-013",
+      "question_text": "What are the three phases of event propagation?",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "Event propagation occurs in three phases: Capturing (from window down to target), Target (reaching the target element), and Bubbling (from target back up to window).",
+      "hint": "Recall the order in which events travel through the DOM.",
+      "tags": ["dom-events", "event-propagation", "bubbling", "capturing"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["dom-events"],
+      "category_slugs": ["browser-apis"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 13",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "Target > Capturing > Bubbling",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "Bubbling > Target > Capturing",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "Target > Bubbling > Capturing",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "Capturing > Target > Bubbling",
+          "is_correct": true
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-014",
+      "question_text": "All objects have prototypes. (True or False?)",
+      "question_type": "true_false",
+      "difficulty": "beginner",
+      "explanation": "All objects have prototypes except for the base object (Object.prototype). The base object has no prototype, but all other objects inherit from it through the prototype chain.",
+      "hint": "Think about the top of the prototype chain.",
+      "tags": ["prototypes", "inheritance", "prototype-chain"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["prototypes"],
+      "category_slugs": ["objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 14",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "True",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "False",
+          "is_correct": true
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-015",
+      "question_text": "What is the output of the following code?\n\n```javascript\nfunction sum(a, b) {\n  return a + b;\n}\n\nsum(1, '2');\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "JavaScript performs type coercion when adding a number and a string. The number 1 is coerced to a string, resulting in string concatenation: '1' + '2' = '12'.",
+      "hint": "Consider how JavaScript handles the + operator with mixed types.",
+      "tags": ["type-coercion", "string-concatenation", "operators"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["type-coercion"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 15",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "NaN",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "TypeError",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "\"12\"",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "3",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-016",
+      "question_text": "What is the output of the following code?\n\n```javascript\nlet number = 0;\nconsole.log(number++);\nconsole.log(++number);\nconsole.log(number);\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "Postfix increment (number++) returns the value before incrementing. Prefix increment (++number) increments first, then returns the new value. Starting at 0: first logs 0 (then becomes 1), prefix increments 1 to 2 and logs 2, final value is 2.",
+      "hint": "Understand the difference between prefix and postfix increment operators.",
+      "tags": ["operators", "increment", "prefix", "postfix"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["data-types"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 16",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "1 1 2",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "1 2 2",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "0 2 2",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "0 1 2",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-017",
+      "question_text": "What is the output of the following code?\n\n```javascript\nfunction getPersonInfo(one, two, three) {\n  console.log(one);\n  console.log(two);\n  console.log(three);\n}\n\nconst person = 'Lydia';\nconst age = 21;\n\ngetPersonInfo`${person} is ${age} years old`;\n```",
+      "question_type": "mcq",
+      "difficulty": "advanced",
+      "explanation": "Tagged template literals pass the string parts as an array as the first argument, followed by each expression value. Here, one receives the array of string parts, two receives 'Lydia', three receives 21.",
+      "hint": "Learn how tagged template literals work in JavaScript.",
+      "tags": ["template-literals", "tagged-templates", "es6"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["functions"],
+      "category_slugs": ["es6-features", "javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 17",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "\"Lydia\" 21 [\"\", \" is \", \" years old\"]",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "[\"\", \" is \", \" years old\"] \"Lydia\" 21",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "\"Lydia\" [\"\", \" is \", \" years old\"] 21",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-018",
+      "question_text": "What is the output of the following code?\n\n```javascript\nfunction checkAge(data) {\n  if (data === { age: 18 }) {\n    console.log('You are an adult!');\n  } else if (data == { age: 18 }) {\n    console.log('You are still an adult.');\n  } else {\n    console.log(`Hmm.. You don't have an age I guess`);\n  }\n}\n\ncheckAge({ age: 18 });\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "Objects are compared by reference, not by value. Even though the objects have the same structure, they refer to different memory locations, so both equality checks return false.",
+      "hint": "Remember how JavaScript compares objects versus primitives.",
+      "tags": ["objects", "equality", "reference-comparison"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["equality-comparison", "objects", "data-types"],
+      "category_slugs": ["javascript-core-concepts", "objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 18",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "You are an adult!",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "You are still an adult.",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "Hmm.. You don't have an age I guess",
+          "is_correct": true
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-019",
+      "question_text": "What is the output of the following code?\n\n```javascript\nfunction getAge(...args) {\n  console.log(typeof args);\n}\n\ngetAge(21);\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "The rest parameter collects arguments into an array. Arrays are objects in JavaScript, so typeof an array returns 'object'.",
+      "hint": "What is the data type of arrays in JavaScript?",
+      "tags": ["rest-parameters", "arrays", "typeof"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["functions", "data-types", "spread-rest"],
+      "category_slugs": ["es6-features", "javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 19",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "\"number\"",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "\"array\"",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "\"object\"",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "\"NaN\"",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-020",
+      "question_text": "What is the output of the following code?\n\n```javascript\nfunction getAge() {\n  'use strict';\n  age = 21;\n  console.log(age);\n}\n\ngetAge();\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "In strict mode, assigning to an undeclared variable throws a ReferenceError. Without strict mode, it would create a global variable.",
+      "hint": "Consider how strict mode affects variable assignment.",
+      "tags": ["strict-mode", "variables", "errors"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["strict-mode", "scope"],
+      "category_slugs": ["error-and-debugging", "javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 20",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "21",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "undefined",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "ReferenceError",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "TypeError",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-021",
+      "question_text": "What is the value of sum?\n\n```javascript\nconst sum = eval('10*10+5');\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "eval() evaluates JavaScript code represented as a string. The expression '10*10+5' is evaluated to the number 105.",
+      "hint": "What does the eval() function do?",
+      "tags": ["eval", "evaluation"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["functions"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 21",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "105",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "\"105\"",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "TypeError",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "\"10*10+5\"",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-022",
+      "question_text": "How long is data stored in sessionStorage accessible?\n\n```javascript\nsessionStorage.setItem('cool_secret', 123);\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "sessionStorage data persists only for the duration of the page session. It is cleared when the tab or browser window is closed. localStorage persists until explicitly cleared.",
+      "hint": "Compare sessionStorage with localStorage.",
+      "tags": ["web-storage", "sessionstorage", "browser-apis"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["storage-apis"],
+      "category_slugs": ["browser-apis"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 22",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "Forever, the data doesn't get lost.",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "When the user closes the tab.",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "When the user closes the entire browser, not only the tab.",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "When the user shuts off their computer.",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-023",
+      "question_text": "What is the output of the following code?\n\n```javascript\nvar num = 8;\nvar num = 10;\n\nconsole.log(num);\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "var allows redeclaration of the same variable within the same scope. The variable will hold the last assigned value. let and const do not allow redeclaration.",
+      "hint": "Understand the redeclaration rules for var, let, and const.",
+      "tags": ["var", "variable-declaration", "scope"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["scope", "data-types"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 23",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "8",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "10",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "SyntaxError",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "ReferenceError",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-024",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst obj = { 1: 'a', 2: 'b', 3: 'c' };\nconst set = new Set([1, 2, 3, 4, 5]);\n\nobj.hasOwnProperty('1');\nobj.hasOwnProperty(1);\nset.has('1');\nset.has(1);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Object keys are always strings (or Symbols). obj.hasOwnProperty('1') and obj.hasOwnProperty(1) both check for the string key '1'. Set elements are not converted to strings; 1 and '1' are different values.",
+      "hint": "Consider how object keys and Set elements are treated differently.",
+      "tags": ["objects", "set", "keys", "type-conversion"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["objects", "maps-sets", "data-types"],
+      "category_slugs": ["objects-and-functions", "es6-features"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 24",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "false true false true",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "false true true true",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "true true false true",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "true true true true",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-025",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst obj = { a: 'one', b: 'two', a: 'three' };\nconsole.log(obj);\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "When an object has duplicate keys, the last value assigned to that key overwrites previous ones. The key retains its original position in the object.",
+      "hint": "What happens when you define the same property multiple times in an object literal?",
+      "tags": ["objects", "properties", "key-collision"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["objects"],
+      "category_slugs": ["objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 25",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "{ a: \"one\", b: \"two\" }",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "{ b: \"two\", a: \"three\" }",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "{ a: \"three\", b: \"two\" }",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "SyntaxError",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-026",
+      "question_text": "The JavaScript global execution context creates two things for you: the global object, and the \"this\" keyword. (True or False?)",
+      "question_type": "true_false",
+      "difficulty": "beginner",
+      "explanation": "When JavaScript code starts running, it creates the global execution context which sets up the global object (window in browsers, global in Node.js) and the 'this' keyword (which refers to the global object in the global context).",
+      "hint": "Think about what is available globally when your script starts.",
+      "tags": ["execution-context", "global-object", "this"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["scope", "this-keyword"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 26",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "True",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "False",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "It depends",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-027",
+      "question_text": "What is the output of the following code?\n\n```javascript\nfor (let i = 1; i < 5; i++) {\n  if (i === 3) continue;\n  console.log(i);\n}\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "The continue statement skips the current iteration when i equals 3. The loop logs 1, 2, then skips 3, and continues with 4.",
+      "hint": "How does the 'continue' statement affect loop execution?",
+      "tags": ["loops", "control-flow", "continue"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": [],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 27",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "1 2",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "1 2 3",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "1 2 4",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "1 3 4",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-028",
+      "question_text": "What is the output of the following code?\n\n```javascript\nString.prototype.giveLydiaPizza = () => {\n  return 'Just give Lydia pizza already!';\n};\n\nconst name = 'Lydia';\n\nconsole.log(name.giveLydiaPizza())\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "String.prototype allows adding methods to all strings. Primitive strings are temporarily wrapped in String objects when methods are called, giving them access to prototype methods.",
+      "hint": "Consider how primitive values can access methods.",
+      "tags": ["prototypes", "string", "methods"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["prototypes", "string-methods"],
+      "category_slugs": ["objects-and-functions", "javascript-methods"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 28",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "\"Just give Lydia pizza already!\"",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "TypeError: not a function",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "SyntaxError",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "undefined",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-029",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst a = {};\nconst b = { key: 'b' };\nconst c = { key: 'c' };\n\na[b] = 123;\na[c] = 456;\n\nconsole.log(a[b]);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Object keys are automatically converted to strings. When using an object as a key, it becomes '[object Object]'. Both assignments set a['[object Object]'] to different values, with the last one (456) persisting.",
+      "hint": "What happens when you use an object as a property key?",
+      "tags": ["objects", "keys", "type-coercion"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["objects", "type-coercion"],
+      "category_slugs": ["objects-and-functions", "javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 29",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "123",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "456",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "undefined",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "ReferenceError",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-030",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst foo = () => console.log('First');\nconst bar = () => setTimeout(() => console.log('Second'));\nconst baz = () => console.log('Third');\n\nbar();\nfoo();\nbaz();\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "setTimeout's callback is asynchronous and goes to the Web API, then to the task queue. It only executes after the call stack is empty, after synchronous code (foo and baz) completes.",
+      "hint": "Consider how the event loop handles setTimeout callbacks.",
+      "tags": ["event-loop", "settimeout", "async", "call-stack"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["event-loop", "timers"],
+      "category_slugs": ["async-javascript"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 30",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "First Second Third",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "First Third Second",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "Second First Third",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "Second Third First",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-031",
+      "question_text": "What is the event.target when clicking the button?\n\n```html\n<div onclick=\"console.log('first div')\">\n  <div onclick=\"console.log('second div')\">\n    <button onclick=\"console.log('button')\">\n      Click!\n    </button>\n  </div>\n</div>\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "event.target refers to the deepest nested element that triggered the event - the element that was actually clicked. In this case, it's the button element.",
+      "hint": "What does event.target represent in event handling?",
+      "tags": ["dom-events", "event-target", "event-propagation"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["dom-events"],
+      "category_slugs": ["browser-apis"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 31",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "Outer div",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "Inner div",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "button",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "An array of all nested elements.",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-032",
+      "question_text": "When you click the paragraph, what's the logged output?\n\n```html\n<div onclick=\"console.log('div')\">\n  <p onclick=\"console.log('p')\">\n    Click here!\n  </p>\n</div>\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "Event handlers execute in the bubbling phase by default. The event bubbles from the target element (p) up through its ancestors, so 'p' is logged first, then 'div'.",
+      "hint": "What is the default phase for event handlers?",
+      "tags": ["dom-events", "event-bubbling", "event-propagation"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["dom-events"],
+      "category_slugs": ["browser-apis"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 32",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "p div",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "div p",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "p",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "div",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-033",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst person = { name: 'Lydia' };\n\nfunction sayHi(age) {\n  return `${this.name} is ${age}`;\n}\n\nconsole.log(sayHi.call(person, 21));\nconsole.log(sayHi.bind(person, 21));\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "call() immediately invokes the function with the specified this context. bind() returns a new function with the this context bound, but does not invoke it.",
+      "hint": "What is the difference between call() and bind()?",
+      "tags": ["this", "call", "bind", "function-methods"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["this-keyword", "functions"],
+      "category_slugs": ["objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 33",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "undefined is 21 Lydia is 21",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "function function",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "Lydia is 21 Lydia is 21",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "Lydia is 21 function",
+          "is_correct": true
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-034",
+      "question_text": "What is the output of the following code?\n\n```javascript\nfunction sayHi() {\n  return (() => 0)();\n}\n\nconsole.log(typeof sayHi());\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "sayHi() returns the result of an immediately invoked function expression (IIFE) that returns 0. typeof 0 returns 'number'.",
+      "hint": "Break down the function execution step by step.",
+      "tags": ["iife", "typeof", "functions"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["functions", "data-types"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 34",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "\"object\"",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "\"number\"",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "\"function\"",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "\"undefined\"",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-035",
+      "question_text": "Which of these values are falsy?\n\n```javascript\n0;\nnew Number(0);\n('');\n(' ');\nnew Boolean(false);\nundefined;\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "The falsy values are: undefined, null, NaN, false, '' (empty string), 0, -0, and 0n. Object wrappers (new Number, new Boolean) are always truthy, even when wrapping falsy values.",
+      "hint": "Remember the list of falsy values in JavaScript.",
+      "tags": ["truthy-falsy", "type-coercion"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["data-types", "type-coercion"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 35",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "0, '', undefined",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "0, new Number(0), '', new Boolean(false), undefined",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "0, '', new Boolean(false), undefined",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "All of them are falsy",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-036",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconsole.log(typeof typeof 1);\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "typeof 1 returns 'number'. typeof 'number' returns 'string' because the operand is a string.",
+      "hint": "Evaluate the expression from the inside out.",
+      "tags": ["typeof", "operators"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["data-types"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 36",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "\"number\"",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "\"string\"",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "\"object\"",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "\"undefined\"",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-037",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst numbers = [1, 2, 3];\nnumbers[10] = 11;\nconsole.log(numbers);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "When you assign to an index beyond the array's length, JavaScript creates empty slots (not undefined values) between the last element and the new index. These empty slots appear differently depending on the environment.",
+      "hint": "What happens when you set an array element at an index larger than the current length?",
+      "tags": ["arrays", "sparse-arrays"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["array-methods", "data-types"],
+      "category_slugs": ["javascript-methods"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 37",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "[1, 2, 3, null x 7, 11]",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "[1, 2, 3, 11]",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "[1, 2, 3, empty x 7, 11]",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "SyntaxError",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-038",
+      "question_text": "What is the output of the following code?\n\n```javascript\n(() => {\n  let x, y;\n  try {\n    throw new Error();\n  } catch (x) {\n    (x = 1), (y = 2);\n    console.log(x);\n  }\n  console.log(x);\n  console.log(y);\n})();\n```",
+      "question_type": "mcq",
+      "difficulty": "advanced",
+      "explanation": "The catch parameter x is block-scoped to the catch block and shadows the outer x. Inside catch, x is set to 1 (overriding the error object), and y is set to 2. Outside catch, outer x remains undefined, while y is 2 (from the catch block's scope).",
+      "hint": "Consider variable scoping within try-catch blocks and parameter shadowing.",
+      "tags": ["scope", "try-catch", "shadowing", "block-scope"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["scope", "error-handling"],
+      "category_slugs": ["error-and-debugging", "javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 38",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "1 undefined 2",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "undefined undefined undefined",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "1 1 2",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "1 undefined undefined",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-039",
+      "question_text": "Everything in JavaScript is either a...",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "JavaScript has two main categories of types: primitives (boolean, null, undefined, number, bigint, string, symbol) and objects (including functions, arrays, dates, etc.). Primitives are immutable and have no methods, though they can be temporarily wrapped for method access.",
+      "hint": "Think about the fundamental type system in JavaScript.",
+      "tags": ["data-types", "primitives", "objects"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["data-types"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 39",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "primitive or object",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "function or object",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "trick question! only objects",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "number or object",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-040",
+      "question_text": "What is the output of the following code?\n\n```javascript\n[[0, 1], [2, 3]].reduce(\n  (acc, cur) => {\n    return acc.concat(cur);\n  },\n  [1, 2],\n);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "reduce starts with initial value [1,2]. First iteration: acc=[1,2], cur=[0,1] → concat → [1,2,0,1]. Second iteration: acc=[1,2,0,1], cur=[2,3] → concat → [1,2,0,1,2,3].",
+      "hint": "Trace through the reduce method step by step with the given initial value.",
+      "tags": ["reduce", "array-methods", "concat"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["array-methods"],
+      "category_slugs": ["javascript-methods"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 40",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "[0, 1, 2, 3, 1, 2]",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "[6, 1, 2]",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "[1, 2, 0, 1, 2, 3]",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "[1, 2, 6]",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-041",
+      "question_text": "What is the output of the following code?\n\n```javascript\n!!null;\n!!'';\n!!1;\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "!! converts a value to its boolean equivalent. null and '' are falsy, so !! returns false. 1 is truthy, so !! returns true.",
+      "hint": "What does the double NOT operator do?",
+      "tags": ["logical-operators", "truthy-falsy", "type-coercion"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["type-coercion", "data-types"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 41",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "false true false",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "false false true",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "false true true",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "true true false",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-042",
+      "question_text": "What does the setInterval method return in the browser?\n\n```javascript\nsetInterval(() => console.log('Hi'), 1000);\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "setInterval returns a unique numeric ID that can be used with clearInterval() to stop the interval from continuing to execute.",
+      "hint": "How do you cancel a setInterval?",
+      "tags": ["timers", "setinterval", "browser-apis"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["timers"],
+      "category_slugs": ["async-javascript", "browser-apis"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 42",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "a unique id",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "the amount of milliseconds specified",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "the passed function",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "undefined",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-043",
+      "question_text": "What does this return?\n\n```javascript\n[...'Lydia'];\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "Strings are iterable in JavaScript. The spread operator spreads each character of the string into individual elements in an array.",
+      "hint": "What happens when you spread a string?",
+      "tags": ["spread-operator", "strings", "iterables"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["spread-rest", "string-methods"],
+      "category_slugs": ["es6-features", "javascript-methods"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 43",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "[\"L\", \"y\", \"d\", \"i\", \"a\"]",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "[\"Lydia\"]",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "[[], \"Lydia\"]",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "[[\"L\", \"y\", \"d\", \"i\", \"a\"]]",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-044",
+      "question_text": "What is the output of the following code?\n\n```javascript\nfunction* generator(i) {\n  yield i;\n  yield i * 2;\n}\n\nconst gen = generator(10);\n\nconsole.log(gen.next().value);\nconsole.log(gen.next().value);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Generator functions pause execution at each yield. First next() returns the first yielded value (10). Second next() continues from where it paused and yields the next value (10 * 2 = 20).",
+      "hint": "How do generator functions and the yield keyword work?",
+      "tags": ["generators", "yield", "iterators"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["functions"],
+      "category_slugs": ["objects-and-functions", "es6-features"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 44",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "[0, 10], [10, 20]",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "20, 20",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "10, 20",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "0, 10 and 10, 20",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-045",
+      "question_text": "What does this return?\n\n```javascript\nconst firstPromise = new Promise((res, rej) => {\n  setTimeout(res, 500, 'one');\n});\n\nconst secondPromise = new Promise((res, rej) => {\n  setTimeout(res, 100, 'two');\n});\n\nPromise.race([firstPromise, secondPromise]).then(res => console.log(res));\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Promise.race settles with the first promise that settles (resolves or rejects). secondPromise resolves after 100ms, faster than firstPromise's 500ms, so 'two' is logged.",
+      "hint": "How does Promise.race() determine which promise to return?",
+      "tags": ["promises", "promise-race", "async"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["promises"],
+      "category_slugs": ["async-javascript"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 45",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "\"one\"",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "\"two\"",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "\"two\" \"one\"",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "\"one\" \"two\"",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-046",
+      "question_text": "What is the output of the following code?\n\n```javascript\nlet person = { name: 'Lydia' };\nconst members = [person];\nperson = null;\n\nconsole.log(members);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "members[0] holds a copy of the reference to the original object. Setting person to null only changes the person variable, not the array element which still references the original object.",
+      "hint": "What happens to array elements when you change the original variable?",
+      "tags": ["references", "objects", "arrays"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["objects", "data-types"],
+      "category_slugs": ["javascript-core-concepts", "objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 46",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "null",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "[null]",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "[{}]",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "[{ name: \"Lydia\" }]",
+          "is_correct": true
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-047",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst person = {\n  name: 'Lydia',\n  age: 21,\n};\n\nfor (const item in person) {\n  console.log(item);\n}\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "The for...in loop iterates over enumerable property names (keys) of an object, not their values.",
+      "hint": "What does for...in iterate over in an object?",
+      "tags": ["loops", "for-in", "objects"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["objects"],
+      "category_slugs": ["objects-and-functions", "javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 47",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "{ name: \"Lydia\" }, { age: 21 }",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "\"name\", \"age\"",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "\"Lydia\", 21",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "[\"name\", \"Lydia\"], [\"age\", 21]",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-048",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconsole.log(3 + 4 + '5');\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "Addition is left-associative. First, 3 + 4 evaluates to 7 (number). Then, 7 + '5' results in type coercion: the number 7 is converted to a string and concatenated with '5', giving '75'.",
+      "hint": "Consider operator associativity and type coercion.",
+      "tags": ["type-coercion", "operators", "associativity"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["type-coercion"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 48",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "\"345\"",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "\"75\"",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "12",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "\"12\"",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-049",
+      "question_text": "What is the value of num?\n\n```javascript\nconst num = parseInt('7*6', 10);\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "parseInt parses until it encounters a character that isn't a valid digit in the specified radix. The '*' is not a valid digit in base 10, so it stops parsing at that point, returning only 7.",
+      "hint": "How does parseInt handle non-numeric characters?",
+      "tags": ["parseint", "type-conversion"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["type-coercion"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 49",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "42",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "\"42\"",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "7",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "NaN",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-050",
+      "question_text": "What is the output of the following code?\n\n```javascript\n[1, 2, 3].map(num => {\n  if (typeof num === 'number') return;\n  return num * 2;\n});\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "The if condition is true for all numbers, so the function returns early with no explicit return value. Functions without a return statement return undefined. map creates a new array with these undefined values.",
+      "hint": "What does a function return when there's no return statement?",
+      "tags": ["map", "array-methods", "return", "undefined"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["array-methods"],
+      "category_slugs": ["javascript-methods"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 50",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "[]",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "[null, null, null]",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "[undefined, undefined, undefined]",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "[ 3 x empty ]",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-051",
+      "question_text": "What is the output of the following code?\n\n```javascript\nfunction getInfo(member, year) {\n  member.name = 'Lydia';\n  year = '1998';\n}\n\nconst person = { name: 'Sarah' };\nconst birthYear = '1997';\n\ngetInfo(person, birthYear);\n\nconsole.log(person, birthYear);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Objects are passed by reference, so modifying member affects the original person object. Strings are passed by value, so modifying year only affects the local copy, not the original birthYear variable.",
+      "hint": "How are objects and primitives passed to functions?",
+      "tags": ["pass-by-reference", "pass-by-value", "objects", "primitives"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["objects", "data-types", "functions"],
+      "category_slugs": ["objects-and-functions", "javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 51",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "{ name: \"Lydia\" }, \"1997\"",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "{ name: \"Sarah\" }, \"1998\"",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "{ name: \"Lydia\" }, \"1998\"",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "{ name: \"Sarah\" }, \"1997\"",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-052",
+      "question_text": "What is the output of the following code?\n\n```javascript\nfunction greeting() {\n  throw 'Hello world!';\n}\n\nfunction sayHi() {\n  try {\n    const data = greeting();\n    console.log('It worked!', data);\n  } catch (e) {\n    console.log('Oh no an error:', e);\n  }\n}\n\nsayHi();\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "throw can throw any expression, not just Error objects. In this case, it throws the string 'Hello world!', which is caught and logged as e in the catch block.",
+      "hint": "What types of values can be thrown in JavaScript?",
+      "tags": ["error-handling", "throw", "try-catch"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["error-handling"],
+      "category_slugs": ["error-and-debugging"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 52",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "It worked! Hello world!",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "Oh no an error: undefined",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "SyntaxError: can only throw Error objects",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "Oh no an error: Hello world!",
+          "is_correct": true
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-053",
+      "question_text": "What is the output of the following code?\n\n```javascript\nfunction Car() {\n  this.make = 'Lamborghini';\n  return { make: 'Maserati' };\n}\n\nconst myCar = new Car();\nconsole.log(myCar.make);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "When a constructor function explicitly returns an object, that object is returned instead of the default this object. The returned object { make: 'Maserati' } overrides the constructor's default behavior.",
+      "hint": "What happens when a constructor function returns an object?",
+      "tags": ["constructors", "new-keyword", "return"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["classes", "functions", "objects"],
+      "category_slugs": ["objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 53",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "\"Lamborghini\"",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "\"Maserati\"",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "ReferenceError",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "TypeError",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-054",
+      "question_text": "What is the output of the following code?\n\n```javascript\n(() => {\n  let x = (y = 10);\n})();\n\nconsole.log(typeof x);\nconsole.log(typeof y);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "y = 10 creates a global variable y (no declaration). let x = y declares block-scoped x. x is not accessible outside the IIFE, so typeof x returns 'undefined'. y is global and exists, typeof y returns 'number'.",
+      "hint": "Understand the difference between assignment and declaration.",
+      "tags": ["scope", "global-variables", "iife"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["scope"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 54",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "\"undefined\", \"number\"",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "\"number\", \"number\"",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "\"object\", \"number\"",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "\"number\", \"undefined\"",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-055",
+      "question_text": "What is the output of the following code?\n\n```javascript\nclass Dog {\n  constructor(name) {\n    this.name = name;\n  }\n}\n\nDog.prototype.bark = function() {\n  console.log(`Woof I am ${this.name}`);\n};\n\nconst pet = new Dog('Mara');\n\npet.bark();\n\ndelete Dog.prototype.bark;\n\npet.bark();\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "The first bark() call works normally. delete removes the bark method from the prototype. The second call tries to invoke undefined as a function, throwing a TypeError.",
+      "hint": "What happens when you delete a method from a prototype?",
+      "tags": ["prototypes", "delete", "methods"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["prototypes", "classes"],
+      "category_slugs": ["objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 55",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "\"Woof I am Mara\", TypeError",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "\"Woof I am Mara\", \"Woof I am Mara\"",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "\"Woof I am Mara\", undefined",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "TypeError, TypeError",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-056",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst set = new Set([1, 1, 2, 3, 4]);\n\nconsole.log(set);\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "Set objects store unique values. Duplicate values are automatically removed when creating a Set from an iterable.",
+      "hint": "How does Set handle duplicate values?",
+      "tags": ["set", "es6", "data-structures"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["maps-sets"],
+      "category_slugs": ["es6-features"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 56",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "[1, 1, 2, 3, 4]",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "[1, 2, 3, 4]",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "{1, 1, 2, 3, 4}",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "{1, 2, 3, 4}",
+          "is_correct": true
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-057",
+      "question_text": "What is the output of the following code?\n\n```javascript\n// counter.js\nlet counter = 10;\nexport default counter;\n\n// index.js\nimport myCounter from './counter';\n\nmyCounter += 1;\n\nconsole.log(myCounter);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "ES6 module imports are read-only bindings. You cannot modify the value of an imported module directly. Attempting to do so throws an error.",
+      "hint": "Can you modify imported values in ES6 modules?",
+      "tags": ["modules", "import", "export", "read-only"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["modules"],
+      "category_slugs": ["javascript-core-concepts", "es6-features"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 57",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "10",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "11",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "Error",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "NaN",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-058",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst name = 'Lydia';\nage = 21;\n\nconsole.log(delete name);\nconsole.log(delete age);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "delete cannot delete variables declared with var, let, or const. name is declared with const, so delete returns false. age is an implicit global (no declaration), so it can be deleted, returning true.",
+      "hint": "What can and cannot be deleted with the delete operator?",
+      "tags": ["delete", "global-object", "variables"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["objects", "scope"],
+      "category_slugs": ["javascript-core-concepts", "objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 58",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "false, true",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "\"Lydia\", 21",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "true, true",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "undefined, undefined",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-059",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst numbers = [1, 2, 3, 4, 5];\nconst [y] = numbers;\n\nconsole.log(y);\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "Array destructuring assigns the first element of the array to the variable y. This is equivalent to const y = numbers[0].",
+      "hint": "How does array destructuring work?",
+      "tags": ["destructuring", "arrays", "es6"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["destructuring"],
+      "category_slugs": ["es6-features"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 59",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "[[1, 2, 3, 4, 5]]",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "[1, 2, 3, 4, 5]",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "1",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "[1]",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-060",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst user = { name: 'Lydia', age: 21 };\nconst admin = { admin: true, ...user };\n\nconsole.log(admin);\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "The spread operator copies enumerable properties from the user object into the new admin object, combining them with its existing properties.",
+      "hint": "What does the spread operator do with objects?",
+      "tags": ["spread-operator", "objects", "es6"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["spread-rest", "objects"],
+      "category_slugs": ["es6-features", "objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 60",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "{ admin: true, user: { name: \"Lydia\", age: 21 } }",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "{ admin: true, name: \"Lydia\", age: 21 }",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "{ admin: true, user: [\"Lydia\", 21] }",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "{ admin: true }",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-061",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst person = { name: 'Lydia' };\n\nObject.defineProperty(person, 'age', { value: 21 });\n\nconsole.log(person);\nconsole.log(Object.keys(person));\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Properties added with defineProperty are non-enumerable by default (unless enumerable: true is specified). Object.keys only returns enumerable properties, so 'age' is not included.",
+      "hint": "What is the default enumerability of defineProperty?",
+      "tags": ["defineproperty", "enumerable", "object-properties"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["object-methods", "objects"],
+      "category_slugs": ["javascript-methods", "objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 61",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "{ name: \"Lydia\", age: 21 }, [\"name\", \"age\"]",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "{ name: \"Lydia\", age: 21 }, [\"name\"]",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "{ name: \"Lydia\"}, [\"name\", \"age\"]",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "{ name: \"Lydia\"}, [\"age\"]",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-062",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst settings = {\n  username: 'lydiahallie',\n  level: 19,\n  health: 90,\n};\n\nconst data = JSON.stringify(settings, ['level', 'health']);\nconsole.log(data);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "JSON.stringify's second parameter (replacer) can be an array of property names to include in the output. Only 'level' and 'health' are included, 'username' is omitted.",
+      "hint": "What does the replacer array do in JSON.stringify?",
+      "tags": ["json", "stringify", "replacer"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["json", "object-methods"],
+      "category_slugs": ["javascript-methods"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 62",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "\"{\"level\":19, \"health\":90}\"",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "\"{\"username\": \"lydiahallie\"}\"",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "\"[\"level\", \"health\"]\"",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "\"{\"username\": \"lydiahallie\", \"level\":19, \"health\":90}\"",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-063",
+      "question_text": "What is the output of the following code?\n\n```javascript\nlet num = 10;\n\nconst increaseNumber = () => num++;\nconst increasePassedNumber = number => number++;\n\nconst num1 = increaseNumber();\nconst num2 = increasePassedNumber(num1);\n\nconsole.log(num1);\nconsole.log(num2);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Postfix increment returns the original value before incrementing. num1 gets 10 (num was 10, then incremented to 11). When num1 (10) is passed to increasePassedNumber, number++ returns 10, then increments the local copy to 11 (doesn't affect num1).",
+      "hint": "Remember how postfix increment works and how arguments are passed.",
+      "tags": ["increment", "operators", "pass-by-value"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["functions", "data-types"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 63",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "10, 10",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "10, 11",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "11, 11",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "11, 12",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-064",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst value = { number: 10 };\n\nconst multiply = (x = { ...value }) => {\n  console.log((x.number *= 2));\n};\n\nmultiply();\nmultiply();\nmultiply(value);\nmultiply(value);\n```",
+      "question_type": "mcq",
+      "difficulty": "advanced",
+      "explanation": "Default parameters are evaluated at call time. First two calls create new objects from value, so they log 20 each (10*2). Third and fourth calls pass the actual value object, which persists modifications: first modifies 10→20, then 20→40.",
+      "hint": "When are default parameter values evaluated? How does object mutation work?",
+      "tags": ["default-parameters", "objects", "spread", "mutation"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["functions", "objects", "spread-rest"],
+      "category_slugs": ["es6-features", "objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 64",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "20, 40, 80, 160",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "20, 40, 20, 40",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "20, 20, 20, 40",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "NaN, NaN, 20, 40",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-065",
+      "question_text": "What is the output of the following code?\n\n```javascript\n[1, 2, 3, 4].reduce((x, y) => console.log(x, y));\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Without an initial value, reduce uses the first element as the accumulator (x=1) and starts with the second element as current value (y=2). The callback doesn't return a value, so accumulator becomes undefined for subsequent iterations.",
+      "hint": "What happens when reduce's callback doesn't return a value?",
+      "tags": ["reduce", "array-methods", "callback"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["array-methods"],
+      "category_slugs": ["javascript-methods"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 65",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "1 2 and 3 3 and 6 4",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "1 2 and 2 3 and 3 4",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "1 undefined and 2 undefined and 3 undefined and 4 undefined",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "1 2 and undefined 3 and undefined 4",
+          "is_correct": true
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-066",
+      "question_text": "With which constructor can we successfully extend the Dog class?\n\n```javascript\nclass Dog {\n  constructor(name) {\n    this.name = name;\n  }\n}\n\nclass Labrador extends Dog {\n  // 1\n  constructor(name, size) {\n    this.size = size;\n  }\n  // 2\n  constructor(name, size) {\n    super(name);\n    this.size = size;\n  }\n  // 3\n  constructor(size) {\n    super(name);\n    this.size = size;\n  }\n  // 4\n  constructor(name, size) {\n    this.name = name;\n    this.size = size;\n  }\n}\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "In derived classes, you must call super() before accessing this. Constructor 2 correctly calls super(name) first, then sets this.size. The others either don't call super or call it incorrectly.",
+      "hint": "What are the rules for constructor in derived classes?",
+      "tags": ["classes", "inheritance", "super", "constructor"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["classes"],
+      "category_slugs": ["objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 66",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "1",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "2",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "3",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "4",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-067",
+      "question_text": "What is the output of the following code?\n\n```javascript\n// index.js\nconsole.log('running index.js');\nimport { sum } from './sum.js';\nconsole.log(sum(1, 2));\n\n// sum.js\nconsole.log('running sum.js');\nexport const sum = (a, b) => a + b;\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "ES6 imports are hoisted and executed before the importing module's code. All imported modules are parsed and executed first, in the order of the dependency graph.",
+      "hint": "What is the execution order with ES6 imports?",
+      "tags": ["modules", "import", "execution-order"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["modules"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 67",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "running index.js, running sum.js, 3",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "running sum.js, running index.js, 3",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "running sum.js, 3, running index.js",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "running index.js, undefined, running sum.js",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-068",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconsole.log(Number(2) === Number(2));\nconsole.log(Boolean(false) === Boolean(false));\nconsole.log(Symbol('foo') === Symbol('foo'));\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Number and Boolean return primitive values when called as functions (not constructors). Symbols are always unique - each Symbol() call creates a completely new symbol, even with the same description.",
+      "hint": "Are Symbols equal even with the same description?",
+      "tags": ["symbols", "equality", "type-conversion"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["symbols", "equality-comparison"],
+      "category_slugs": ["es6-features", "javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 68",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "true, true, false",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "false, true, false",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "true, false, true",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "true, true, true",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-069",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst name = 'Lydia Hallie';\nconsole.log(name.padStart(13));\nconsole.log(name.padStart(2));\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "padStart adds padding to reach the specified total length. 'Lydia Hallie' has length 12, so padStart(13) adds 1 space at the beginning. If target length is less than or equal to current length, no padding is added.",
+      "hint": "How does padStart work when target length is less than string length?",
+      "tags": ["string-methods", "padstart", "es6"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["string-methods"],
+      "category_slugs": ["javascript-methods", "es6-features"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 69",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "\"Lydia Hallie\", \"Lydia Hallie\"",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "\" Lydia Hallie\", \" Lydia Hallie\" (\"[13x whitespace]Lydia Hallie\", \"[2x whitespace]Lydia Hallie\")",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "\" Lydia Hallie\", \"Lydia Hallie\" (\"[1x whitespace]Lydia Hallie\", \"Lydia Hallie\")",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "\"Lydia Hallie\", \"Lyd\"",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-070",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconsole.log('🥑' + '💻');\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "The + operator concatenates strings. Emojis are Unicode characters represented as strings, so they are concatenated normally.",
+      "hint": "How does JavaScript handle emojis in strings?",
+      "tags": ["strings", "concatenation", "unicode"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["string-methods"],
+      "category_slugs": ["javascript-methods"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 70",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "\"🥑💻\"",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "257548",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "A string containing their code points",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "Error",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-071",
+      "question_text": "How can we log the values that are commented out after the console.log statement?\n\n```javascript\nfunction* startGame() {\n  const answer = yield 'Do you love JavaScript?';\n  if (answer !== 'Yes') {\n    return \"Oh wow... Guess we're done here\";\n  }\n  return 'JavaScript loves you back ❤️';\n}\n\nconst game = startGame();\nconsole.log(/* 1 */); // Do you love JavaScript?\nconsole.log(/* 2 */); // JavaScript loves you back ❤️\n```",
+      "question_type": "mcq",
+      "difficulty": "advanced",
+      "explanation": "First call to next() without arguments yields the first yield expression value. Second call passes 'Yes' to replace the yield expression, which becomes the answer variable, allowing the function to continue to the next return.",
+      "hint": "How do you pass values back into a generator function?",
+      "tags": ["generators", "yield", "next"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["functions"],
+      "category_slugs": ["es6-features", "objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 71",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "game.next(\"Yes\").value and game.next().value",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "game.next.value(\"Yes\") and game.next.value()",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "game.next().value and game.next(\"Yes\").value",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "game.next.value() and game.next.value(\"Yes\")",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-072",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconsole.log(String.raw`Hello\\nworld`);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "String.raw is a tag function that returns the raw string form, ignoring escape sequences like \\n. Backslashes are interpreted as literal backslashes, not as escape characters.",
+      "hint": "What does String.raw do to escape sequences?",
+      "tags": ["string-raw", "template-literals", "escape-sequences"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["string-methods"],
+      "category_slugs": ["javascript-methods", "es6-features"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 72",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "Hello world!",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "Hello <br />&nbsp; &nbsp; &nbsp;world",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "Hello\\nworld",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "Hello\\n <br /> &nbsp; &nbsp; &nbsp;world",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-073",
+      "question_text": "What is the output of the following code?\n\n```javascript\nasync function getData() {\n  return await Promise.resolve('I made it!');\n}\n\nconst data = getData();\nconsole.log(data);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Async functions always return a Promise. The function hasn't resolved yet when data is assigned, so data is a pending Promise. To get the resolved value, you need to use .then() or await.",
+      "hint": "What does an async function return?",
+      "tags": ["async-await", "promises", "async-functions"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["async-await", "promises"],
+      "category_slugs": ["async-javascript"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 73",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "\"I made it!\"",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "Promise {<resolved>: \"I made it!\"}",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "Promise {<pending>}",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "undefined",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-074",
+      "question_text": "What is the output of the following code?\n\n```javascript\nfunction addToList(item, list) {\n  return list.push(item);\n}\n\nconst result = addToList('apple', ['banana']);\nconsole.log(result);\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "Array.push() returns the new length of the array, not the array itself. After pushing 'apple' to ['banana'], the array has length 2, so 2 is returned.",
+      "hint": "What does the push method return?",
+      "tags": ["array-methods", "push", "return-value"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["array-methods"],
+      "category_slugs": ["javascript-methods"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 74",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "['apple', 'banana']",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "2",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "true",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "undefined",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-075",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst box = { x: 10, y: 20 };\n\nObject.freeze(box);\n\nconst shape = box;\nshape.x = 100;\n\nconsole.log(shape);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Object.freeze makes an object immutable - properties cannot be added, removed, or changed. shape references the same frozen object, so attempting to modify x fails silently (or throws in strict mode).",
+      "hint": "What does Object.freeze do to an object?",
+      "tags": ["freeze", "immutability", "object-methods"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["object-methods", "objects"],
+      "category_slugs": ["javascript-methods", "objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 75",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "{ x: 100, y: 20 }",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "{ x: 10, y: 20 }",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "{ x: 100 }",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "ReferenceError",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-076",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst { firstName: myName } = { firstName: 'Lydia' };\n\nconsole.log(firstName);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "This code uses destructuring with renaming: firstName is extracted and assigned to a new variable myName. The original property name firstName is not available as a variable - only myName exists.",
+      "hint": "What variable names are created when destructuring with renaming?",
+      "tags": ["destructuring", "objects", "renaming"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["destructuring"],
+      "category_slugs": ["es6-features"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 76",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "\"Lydia\"",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "\"myName\"",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "undefined",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "ReferenceError",
+          "is_correct": true
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-077",
+      "question_text": "Is this a pure function?\n\n```javascript\nfunction sum(a, b) {\n  return a + b;\n}\n```",
+      "question_type": "true_false",
+      "difficulty": "beginner",
+      "explanation": "A pure function always returns the same output for the same input and has no side effects. sum(a,b) always returns a+b with no external dependencies or modifications, making it a pure function.",
+      "hint": "What are the characteristics of a pure function?",
+      "tags": ["pure-functions", "functional-programming"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["functions"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 77",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "Yes",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "No",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-078",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst add = () => {\n  const cache = {};\n  return num => {\n    if (num in cache) {\n      return `From cache! ${cache[num]}`;\n    } else {\n      const result = num + 10;\n      cache[num] = result;\n      return `Calculated! ${result}`;\n    }\n  };\n};\n\nconst addFunction = add();\nconsole.log(addFunction(10));\nconsole.log(addFunction(10));\nconsole.log(addFunction(5 * 2));\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "This is a memoized function. The cache persists across calls due to closure. First call with 10 calculates and caches. Second call with 10 returns from cache. 5*2 evaluates to 10, which is already in cache.",
+      "hint": "How does closure help with memoization?",
+      "tags": ["closures", "memoization", "caching"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["functions", "scope"],
+      "category_slugs": ["javascript-core-concepts", "objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 78",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "Calculated! 20 Calculated! 20 Calculated! 20",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "Calculated! 20 From cache! 20 Calculated! 20",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "Calculated! 20 From cache! 20 From cache! 20",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "Calculated! 20 From cache! 20 Error",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-079",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst myLifeSummedUp = ['☕', '💻', '🍷', '🍫'];\n\nfor (let item in myLifeSummedUp) {\n  console.log(item);\n}\n\nfor (let item of myLifeSummedUp) {\n  console.log(item);\n}\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "for...in iterates over enumerable property names (array indices). for...of iterates over iterable values (array elements). Arrays are objects with indices as keys and values as elements.",
+      "hint": "What's the difference between for...in and for...of?",
+      "tags": ["loops", "for-in", "for-of", "iterables"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["array-methods"],
+      "category_slugs": ["javascript-methods", "es6-features"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 79",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "0 1 2 3 and \"☕\" \"💻\" \"🍷\" \"🍫\"",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "\"☕\" \"💻\" \"🍷\" \"🍫\" and \"☕\" \"💻\" \"🍷\" \"🍫\"",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "\"☕\" \"💻\" \"🍷\" \"🍫\" and 0 1 2 3",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "0 1 2 3 and {0: \"☕\", 1: \"💻\", 2: \"🍷\", 3: \"🍫\"}",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-080",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst list = [1 + 2, 1 * 2, 1 / 2];\nconsole.log(list);\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "Array elements can contain expressions, which are evaluated when the array is created. The expressions are computed to their results: 3, 2, and 0.5.",
+      "hint": "When are expressions in array literals evaluated?",
+      "tags": ["arrays", "expressions", "evaluation"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["array-methods", "data-types"],
+      "category_slugs": ["javascript-methods", "javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 80",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "[\"1 + 2\", \"1 * 2\", \"1 / 2\"]",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "[\"12\", 2, 0.5]",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "[3, 2, 0.5]",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "[1, 1, 1]",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-081",
+      "question_text": "What is the output of the following code?\n\n```javascript\nfunction sayHi(name) {\n  return `Hi there, ${name}`;\n}\n\nconsole.log(sayHi());\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "When a function parameter is not provided, it defaults to undefined. The template literal converts undefined to the string 'undefined', resulting in 'Hi there, undefined'.",
+      "hint": "What is the default value of missing function parameters?",
+      "tags": ["functions", "parameters", "default-values"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["functions"],
+      "category_slugs": ["objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 81",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "Hi there,",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "Hi there, undefined",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "Hi there, null",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "ReferenceError",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-082",
+      "question_text": "What is the output of the following code?\n\n```javascript\nvar status = '😎';\n\nsetTimeout(() => {\n  const status = '😍';\n\n  const data = {\n    status: '🥑',\n    getStatus() {\n      return this.status;\n    },\n  };\n\n  console.log(data.getStatus());\n  console.log(data.getStatus.call(this));\n}, 0);\n```",
+      "question_type": "mcq",
+      "difficulty": "advanced",
+      "explanation": "First log: data.getStatus() uses the object's status property ('🥑'). Second log: .call(this) changes the context to the setTimeout's this, which in arrow functions inherits from outer scope (global), where status='😎'.",
+      "hint": "What does 'this' refer to in different contexts and with call()?",
+      "tags": ["this", "call", "arrow-functions", "context"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["this-keyword", "functions"],
+      "category_slugs": ["objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 82",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "\"🥑\" and \"😍\"",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "\"🥑\" and \"😎\"",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "\"😍\" and \"😎\"",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "\"😎\" and \"😎\"",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-083",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst person = {\n  name: 'Lydia',\n  age: 21,\n};\n\nlet city = person.city;\ncity = 'Amsterdam';\n\nconsole.log(person);\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "city is assigned the value of person.city (undefined), then reassigned to 'Amsterdam'. This doesn't affect the person object because city is a separate variable, not a reference to the object property.",
+      "hint": "Does assigning a variable affect the original object?",
+      "tags": ["objects", "assignment", "references"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["objects"],
+      "category_slugs": ["objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 83",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "{ name: \"Lydia\", age: 21 }",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "{ name: \"Lydia\", age: 21, city: \"Amsterdam\" }",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "{ name: \"Lydia\", age: 21, city: undefined }",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "\"Amsterdam\"",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-084",
+      "question_text": "What is the output of the following code?\n\n```javascript\nfunction checkAge(age) {\n  if (age < 18) {\n    const message = \"Sorry, you're too young.\";\n  } else {\n    const message = \"Yay! You're old enough!\";\n  }\n\n  return message;\n}\n\nconsole.log(checkAge(21));\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "const and let are block-scoped. message is declared inside if/else blocks and is not accessible outside those blocks. Trying to return it throws a ReferenceError.",
+      "hint": "Where are const and let variables accessible?",
+      "tags": ["scope", "block-scope", "const", "let"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["scope"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 84",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "\"Sorry, you're too young.\"",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "\"Yay! You're old enough!\"",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "ReferenceError",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "undefined",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-085",
+      "question_text": "What kind of information would get logged?\n\n```javascript\nfetch('https://www.website.com/api/user/1')\n  .then(res => res.json())\n  .then(res => console.log(res));\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "Each .then receives the return value of the previous .then. The first .then returns res.json(), which is a Promise that resolves to the parsed JSON. The second .then receives that parsed JSON value.",
+      "hint": "What value is passed between .then callbacks?",
+      "tags": ["promises", "fetch", "then", "chaining"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["promises"],
+      "category_slugs": ["async-javascript"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 85",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "The result of the fetch method.",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "The result of the second invocation of the fetch method.",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "The result of the callback in the previous .then().",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "It would always be undefined.",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-086",
+      "question_text": "Which option is a way to set hasName equal to true, provided you cannot pass true as an argument?\n\n```javascript\nfunction getName(name) {\n  const hasName = //\n}\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "!!name converts the name value to its boolean equivalent. This returns true for any truthy value passed to the function, which matches the requirement of setting hasName to true without explicitly passing true.",
+      "hint": "How can you convert any value to its boolean equivalent?",
+      "tags": ["boolean-conversion", "truthy-falsy", "operators"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["type-coercion", "data-types"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 86",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "!!name",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "name",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "new Boolean(name)",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "name.length",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-087",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconsole.log('I want pizza'[0]);\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "Strings can be accessed using bracket notation with indices, like arrays. Index 0 returns the first character of the string, which is 'I'.",
+      "hint": "Can you access characters in a string by index?",
+      "tags": ["strings", "indexing", "bracket-notation"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["string-methods"],
+      "category_slugs": ["javascript-methods"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 87",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "\"\"\"",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "\"I\"",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "SyntaxError",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "undefined",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-088",
+      "question_text": "What is the output of the following code?\n\n```javascript\nfunction sum(num1, num2 = num1) {\n  console.log(num1 + num2);\n}\n\nsum(10);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Default parameters can reference previous parameters. Here, num2 defaults to num1. With one argument (10), num1=10, num2 defaults to num1 (10), so 10+10=20.",
+      "hint": "Can default parameters reference other parameters?",
+      "tags": ["default-parameters", "functions", "es6"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["functions"],
+      "category_slugs": ["es6-features", "objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 88",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "NaN",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "20",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "ReferenceError",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "undefined",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-089",
+      "question_text": "What is the output of the following code?\n\n```javascript\n// module.js\nexport default () => 'Hello world';\nexport const name = 'Lydia';\n\n// index.js\nimport * as data from './module';\n\nconsole.log(data);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "import * creates an object containing all exports. The default export becomes a property named 'default', and named exports become properties with their names.",
+      "hint": "How does import * handle default and named exports?",
+      "tags": ["modules", "import", "export", "default-export"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["modules"],
+      "category_slugs": ["javascript-core-concepts", "es6-features"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 89",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "{ default: function default(), name: \"Lydia\" }",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "{ default: function default() }",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "{ default: \"Hello world\", name: \"Lydia\" }",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "Global object of module.js",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-090",
+      "question_text": "What is the output of the following code?\n\n```javascript\nclass Person {\n  constructor(name) {\n    this.name = name;\n  }\n}\n\nconst member = new Person('John');\nconsole.log(typeof member);\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "Classes in JavaScript are syntactic sugar over constructor functions. Instances created with new are objects, so typeof returns 'object'.",
+      "hint": "What is the type of a class instance?",
+      "tags": ["classes", "typeof", "instances"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["classes", "data-types"],
+      "category_slugs": ["objects-and-functions", "javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 90",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "\"class\"",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "\"function\"",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "\"object\"",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "\"string\"",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-091",
+      "question_text": "What is the output of the following code?\n\n```javascript\nlet newList = [1, 2, 3].push(4);\n\nconsole.log(newList.push(5));\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "push() returns the new length of the array, not the array itself. newList becomes the number 4 (the length after pushing 4). Trying to call push on a number throws a TypeError.",
+      "hint": "What does push() return?",
+      "tags": ["array-methods", "push", "return-value", "typeerror"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["array-methods"],
+      "category_slugs": ["javascript-methods"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 91",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "[1, 2, 3, 4, 5]",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "[1, 2, 3, 5]",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "[1, 2, 3, 4]",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "Error",
+          "is_correct": true
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-092",
+      "question_text": "What is the output of the following code?\n\n```javascript\nfunction giveLydiaPizza() {\n  return 'Here is pizza!';\n}\n\nconst giveLydiaChocolate = () =>\n  \"Here's chocolate... now go hit the gym already.\";\n\nconsole.log(giveLydiaPizza.prototype);\nconsole.log(giveLydiaChocolate.prototype);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Regular functions have a prototype property (an object with a constructor). Arrow functions do not have a prototype property - they cannot be used as constructors.",
+      "hint": "Do arrow functions have a prototype property?",
+      "tags": ["prototype", "arrow-functions", "functions"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["prototypes", "functions"],
+      "category_slugs": ["objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 92",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "{ constructor: ...} { constructor: ...}",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "{} { constructor: ...}",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "{ constructor: ...} {}",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "{ constructor: ...} undefined",
+          "is_correct": true
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-093",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst person = {\n  name: 'Lydia',\n  age: 21,\n};\n\nfor (const [x, y] of Object.entries(person)) {\n  console.log(x, y);\n}\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Object.entries returns an array of [key, value] pairs. The for...of loop with destructuring assigns each pair's key to x and value to y.",
+      "hint": "What does Object.entries return?",
+      "tags": ["object-entries", "destructuring", "loops"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["object-methods", "destructuring"],
+      "category_slugs": ["javascript-methods", "es6-features"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 93",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "name Lydia and age 21",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "[\"name\", \"Lydia\"] and [\"age\", 21]",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "[\"name\", \"age\"] and undefined",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "Error",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-094",
+      "question_text": "What is the output of the following code?\n\n```javascript\nfunction getItems(fruitList, ...args, favoriteFruit) {\n  return [...fruitList, ...args, favoriteFruit]\n}\n\ngetItems([\"banana\", \"apple\"], \"pear\", \"orange\")\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "The rest parameter must be the last parameter in a function definition. Having parameters after ...args is invalid syntax and throws a SyntaxError.",
+      "hint": "Where can a rest parameter appear in a function definition?",
+      "tags": ["rest-parameters", "syntax", "functions"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["spread-rest", "functions"],
+      "category_slugs": ["es6-features", "objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 94",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "[\"banana\", \"apple\", \"pear\", \"orange\"]",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "[[\"banana\", \"apple\"], \"pear\", \"orange\"]",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "[\"banana\", \"apple\", [\"pear\"], \"orange\"]",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "SyntaxError",
+          "is_correct": true
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-095",
+      "question_text": "What is the output of the following code?\n\n```javascript\nfunction nums(a, b) {\n  if (a > b) console.log('a is bigger');\n  else console.log('b is bigger');\n  return\n  a + b;\n}\n\nconsole.log(nums(4, 2));\nconsole.log(nums(1, 2));\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Due to Automatic Semicolon Insertion (ASI), a semicolon is inserted after 'return', making it a standalone statement. The function returns undefined, and a + b is never executed.",
+      "hint": "How does Automatic Semicolon Insertion affect return statements?",
+      "tags": ["asi", "return", "semicolons"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["functions"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 95",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "a is bigger, 6 and b is bigger, 3",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "a is bigger, undefined and b is bigger, undefined",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "undefined and undefined",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "SyntaxError",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-096",
+      "question_text": "What is the output of the following code?\n\n```javascript\nclass Person {\n  constructor() {\n    this.name = 'Lydia';\n  }\n}\n\nPerson = class AnotherPerson {\n  constructor() {\n    this.name = 'Sarah';\n  }\n};\n\nconst member = new Person();\nconsole.log(member.name);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Classes can be reassigned like variables. Person is reassigned to AnotherPerson before instantiation, so the instance uses the new class definition with name 'Sarah'.",
+      "hint": "Can you reassign a class to another class?",
+      "tags": ["classes", "reassignment"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["classes"],
+      "category_slugs": ["objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 96",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "\"Lydia\"",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "\"Sarah\"",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "Error: cannot redeclare Person",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "SyntaxError",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-097",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst info = {\n  [Symbol('a')]: 'b',\n};\n\nconsole.log(info);\nconsole.log(Object.keys(info));\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Symbol keys are not enumerable, so they don't appear in Object.keys(). However, when logging the entire object, the Symbol property is visible.",
+      "hint": "Are Symbol properties enumerable?",
+      "tags": ["symbols", "enumerable", "object-keys"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["symbols", "object-methods"],
+      "category_slugs": ["es6-features", "javascript-methods"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 97",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "{Symbol('a'): 'b'} and [\"{Symbol('a')\"]",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "{} and []",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "{ a: \"b\" } and [\"a\"]",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "{Symbol('a'): 'b'} and []",
+          "is_correct": true
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-098",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst getList = ([x, ...y]) => [x, y]\nconst getUser = user => { name: user.name, age: user.age }\n\nconst list = [1, 2, 3, 4]\nconst user = { name: \"Lydia\", age: 21 }\n\nconsole.log(getList(list))\nconsole.log(getUser(user))\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "getList destructures the array: x gets first element, y gets rest as array. getUser's arrow function with {} is interpreted as a block, not an object return. To return an object, it needs parentheses: ({ name: user.name, age: user.age }).",
+      "hint": "How do you return an object from an arrow function?",
+      "tags": ["arrow-functions", "destructuring", "rest-parameters", "object-return"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["functions", "destructuring", "spread-rest"],
+      "category_slugs": ["es6-features", "objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 98",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "[1, [2, 3, 4]] and SyntaxError",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "[1, [2, 3, 4]] and { name: \"Lydia\", age: 21 }",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "[1, 2, 3, 4] and { name: \"Lydia\", age: 21 }",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "Error and { name: \"Lydia\", age: 21 }",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-099",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst name = 'Lydia';\n\nconsole.log(name());\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "name is a string, not a function. Attempting to invoke it as a function throws a TypeError because strings are not callable.",
+      "hint": "What happens when you try to call a non-function?",
+      "tags": ["typeerror", "function-call", "strings"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["error-handling", "data-types"],
+      "category_slugs": ["error-and-debugging", "javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 99",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "SyntaxError",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "ReferenceError",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "TypeError",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "undefined",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-100",
+      "question_text": "What is the value of output?\n\n```javascript\nconst output = `${[] && 'Im'}possible!\nYou should${'' && `n't`} see a therapist after so much JavaScript lol`;\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "[] is truthy, so [] && 'Im' evaluates to 'Im'. '' is falsy, so '' && `n't` evaluates to '' (falsy value). The template literal concatenates: 'Im' + 'possible!' + 'You should' + '' + ' see a therapist...'",
+      "hint": "How does the && operator work with truthy and falsy values?",
+      "tags": ["logical-operators", "template-literals", "truthy-falsy"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["type-coercion", "data-types"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 100",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "possible! You should see a therapist after so much JavaScript lol",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "Impossible! You should see a therapist after so much JavaScript lol",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "possible! You shouldn't see a therapist after so much JavaScript lol",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "Impossible! You shouldn't see a therapist after so much JavaScript lol",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-101",
+      "question_text": "What is the value of output?\n\n```javascript\nconst one = false || {} || null;\nconst two = null || false || '';\nconst three = [] || 0 || true;\n\nconsole.log(one, two, three);\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "The || operator returns the first truthy operand, or the last operand if all are falsy. {} is truthy, so one = {}. All operands for two are falsy, so two = '' (last). [] is truthy, so three = [].",
+      "hint": "How does the logical OR (||) operator determine its return value?",
+      "tags": ["logical-operators", "truthy-falsy", "short-circuiting"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["type-coercion"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 101",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "false null []",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "null \"\" true",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "{} \"\" []",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "null null true",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-102",
+      "question_text": "What is the value of output?\n\n```javascript\nconst myPromise = () => Promise.resolve('I have resolved!');\n\nfunction firstFunction() {\n  myPromise().then(res => console.log(res));\n  console.log('second');\n}\n\nasync function secondFunction() {\n  console.log(await myPromise());\n  console.log('second');\n}\n\nfirstFunction();\nsecondFunction();\n```",
+      "question_type": "mcq",
+      "difficulty": "advanced",
+      "explanation": "In firstFunction, synchronous code runs first ('second'), then microtask (promise resolution). In secondFunction, await pauses execution until promise resolves, so 'I have resolved!' logs before 'second'.",
+      "hint": "How does await differ from .then() in execution order?",
+      "tags": ["async-await", "promises", "event-loop", "microtasks"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["async-await", "promises", "event-loop"],
+      "category_slugs": ["async-javascript"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 102",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "I have resolved!, second and I have resolved!, second",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "second, I have resolved! and second, I have resolved!",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "I have resolved!, second and second, I have resolved!",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "second, I have resolved! and I have resolved!, second",
+          "is_correct": true
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-103",
+      "question_text": "What is the value of output?\n\n```javascript\nconst set = new Set();\n\nset.add(1);\nset.add('Lydia');\nset.add({ name: 'Lydia' });\n\nfor (let item of set) {\n  console.log(item + 2);\n}\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "The + operator performs different coercions: 1+2=3 (number), 'Lydia'+2='Lydia2' (string concatenation), {}+2 converts object to string '[object Object]' then concatenates: '[object Object]2'.",
+      "hint": "How does the + operator handle different types?",
+      "tags": ["set", "type-coercion", "operators", "iteration"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["maps-sets", "type-coercion"],
+      "category_slugs": ["es6-features", "javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 103",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "3, NaN, NaN",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "3, 7, NaN",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "3, Lydia2, [object Object]2",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "\"12\", Lydia2, [object Object]2",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-104",
+      "question_text": "What is its value?\n\n```javascript\nPromise.resolve(5);\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "Promise.resolve returns a Promise that is resolved with the given value. It returns a Promise object in the fulfilled state with value 5.",
+      "hint": "What does Promise.resolve return?",
+      "tags": ["promises", "promise-resolve"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["promises"],
+      "category_slugs": ["async-javascript"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 104",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "5",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "Promise {<pending>: 5}",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "Promise {<fulfilled>: 5}",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "Error",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-105",
+      "question_text": "What is its value?\n\n```javascript\nfunction compareMembers(person1, person2 = person) {\n  if (person1 !== person2) {\n    console.log('Not the same!');\n  } else {\n    console.log('They are the same!');\n  }\n}\n\nconst person = { name: 'Lydia' };\n\ncompareMembers(person);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Both person1 (argument) and person2 (default parameter) reference the same object in memory. Strict inequality (!==) checks reference equality, so they are considered equal.",
+      "hint": "When comparing objects, what does strict equality check?",
+      "tags": ["objects", "equality", "reference", "default-parameters"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["equality-comparison", "objects"],
+      "category_slugs": ["javascript-core-concepts", "objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 105",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "Not the same!",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "They are the same!",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "ReferenceError",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "SyntaxError",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-106",
+      "question_text": "What is its value?\n\n```javascript\nconst colorConfig = {\n  red: true,\n  blue: false,\n  green: true,\n  black: true,\n  yellow: false,\n};\n\nconst colors = ['pink', 'red', 'blue'];\n\nconsole.log(colorConfig.colors[1]);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "colorConfig.colors attempts to access a property named 'colors' on colorConfig, which doesn't exist (returns undefined). Trying to access index 1 of undefined throws a TypeError.",
+      "hint": "What happens when you try to access a property that doesn't exist on an object?",
+      "tags": ["objects", "property-access", "typeerror"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["objects"],
+      "category_slugs": ["objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 106",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "true",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "false",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "undefined",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "TypeError",
+          "is_correct": true
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-107",
+      "question_text": "What is its value?\n\n```javascript\nconsole.log('❤️' === '❤️');\n```",
+      "question_type": "true_false",
+      "difficulty": "beginner",
+      "explanation": "Emojis are represented by Unicode code points. The same emoji always has the same Unicode representation, so comparing two identical emoji strings returns true.",
+      "hint": "Are emojis represented consistently in JavaScript strings?",
+      "tags": ["strings", "unicode", "equality"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["string-methods", "equality-comparison"],
+      "category_slugs": ["javascript-methods", "javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 107",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "true",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "false",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-108",
+      "question_text": "Which of these methods modifies the original array?\n\n```javascript\nconst emojis = ['✨', '🥑', '😍'];\n\nemojis.map(x => x + '✨');\nemojis.filter(x => x !== '🥑');\nemojis.find(x => x !== '🥑');\nemojis.reduce((acc, cur) => acc + '✨');\nemojis.slice(1, 2, '✨');\nemojis.splice(1, 2, '✨');\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Only splice modifies the original array by deleting/replacing elements. map, filter, slice return new arrays. find returns an element. reduce returns a reduced value.",
+      "hint": "Which array methods mutate the original array?",
+      "tags": ["array-methods", "mutation", "splice"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["array-methods"],
+      "category_slugs": ["javascript-methods"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 108",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "All of them",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "map reduce slice splice",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "map slice splice",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "splice",
+          "is_correct": true
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-109",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst food = ['🍕', '🍫', '🥑', '🍔'];\nconst info = { favoriteFood: food[0] };\n\ninfo.favoriteFood = '🍝';\n\nconsole.log(food);\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "food[0] is a primitive string value. When assigned to info.favoriteFood, it copies that value, not a reference to the array element. Changing info.favoriteFood doesn't affect the original array.",
+      "hint": "Does assigning an array element to a variable create a reference?",
+      "tags": ["primitives", "assignment", "arrays"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["data-types", "arrays"],
+      "category_slugs": ["javascript-core-concepts", "javascript-methods"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 109",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "['🍕', '🍫', '🥑', '🍔']",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "['🍝', '🍫', '🥑', '🍔']",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "['🍝', '🍕', '🍫', '🥑', '🍔']",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "ReferenceError",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-110",
+      "question_text": "What does this method do?\n\n```javascript\nJSON.parse();\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "JSON.parse converts a JSON string into a JavaScript value or object. It's the inverse of JSON.stringify.",
+      "hint": "What is the purpose of JSON.parse?",
+      "tags": ["json", "parse", "serialization"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["json"],
+      "category_slugs": ["javascript-methods"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 110",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "Parses JSON to a JavaScript value",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "Parses a JavaScript object to JSON",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "Parses any JavaScript value to JSON",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "Parses JSON to a JavaScript object only",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-111",
+      "question_text": "What is the output of the following code?\n\n```javascript\nlet name = 'Lydia';\n\nfunction getName() {\n  console.log(name);\n  let name = 'Sarah';\n}\n\ngetName();\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "The getName function has its own name variable declared with let. Due to the temporal dead zone, accessing name before its declaration (even though there's an outer name) throws a ReferenceError.",
+      "hint": "What happens when you try to access a let variable before declaration?",
+      "tags": ["scope", "hoisting", "temporal-dead-zone", "let"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["hoisting", "scope"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 111",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "Lydia",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "Sarah",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "undefined",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "ReferenceError",
+          "is_correct": true
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-112",
+      "question_text": "What is the output of the following code?\n\n```javascript\nfunction* generatorOne() {\n  yield ['a', 'b', 'c'];\n}\n\nfunction* generatorTwo() {\n  yield* ['a', 'b', 'c'];\n}\n\nconst one = generatorOne();\nconst two = generatorTwo();\n\nconsole.log(one.next().value);\nconsole.log(two.next().value);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "yield returns the entire array as one value. yield* delegates to another iterable, yielding each item individually. So one yields the array, two yields 'a' first.",
+      "hint": "What's the difference between yield and yield*?",
+      "tags": ["generators", "yield", "yield-star", "iterables"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["functions"],
+      "category_slugs": ["es6-features", "objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 112",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "a and a",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "a and undefined",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "['a', 'b', 'c'] and a",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "a and ['a', 'b', 'c']",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-113",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconsole.log(`${(x => x)('I love')} to program`);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "The expression inside ${} is evaluated first. The arrow function (x => x) is immediately invoked with 'I love', returning 'I love'. This is then interpolated into the template literal.",
+      "hint": "How are expressions evaluated in template literals?",
+      "tags": ["template-literals", "arrow-functions", "iife"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["functions"],
+      "category_slugs": ["es6-features", "javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 113",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "I love to program",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "undefined to program",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "${(x => x)('I love') to program",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "TypeError",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-114",
+      "question_text": "What will happen?\n\n```javascript\nlet config = {\n  alert: setInterval(() => {\n    console.log('Alert!');\n  }, 1000),\n};\n\nconfig = null;\n```",
+      "question_type": "mcq",
+      "difficulty": "advanced",
+      "explanation": "setInterval creates a timer that continues running even if the object referencing it is set to null. The arrow function maintains a closure over the timer, preventing garbage collection. The interval must be cleared with clearInterval.",
+      "hint": "Does setting an object to null stop its setInterval?",
+      "tags": ["setinterval", "memory-leaks", "garbage-collection", "closures"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["timers", "event-loop"],
+      "category_slugs": ["async-javascript", "browser-apis"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 114",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "The setInterval callback won't be invoked",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "The setInterval callback gets invoked once",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "The setInterval callback will still be called every second",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "We never invoked config.alert(), config is null",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-115",
+      "question_text": "Which method(s) will return the value 'Hello world!'?\n\n```javascript\nconst myMap = new Map();\nconst myFunc = () => 'greeting';\n\nmyMap.set(myFunc, 'Hello world!');\n\n//1\nmyMap.get('greeting');\n//2\nmyMap.get(myFunc);\n//3\nmyMap.get(() => 'greeting');\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Map keys are compared by reference. The key is the specific function myFunc. 'greeting' is a different value (string). () => 'greeting' creates a new function with a different reference, so only myMap.get(myFunc) returns the value.",
+      "hint": "How does Map compare keys for objects and functions?",
+      "tags": ["map", "keys", "reference-comparison"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["maps-sets"],
+      "category_slugs": ["es6-features"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 115",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "1",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "2",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "2 and 3",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "All of them",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-116",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst person = {\n  name: 'Lydia',\n  age: 21,\n};\n\nconst changeAge = (x = { ...person }) => (x.age += 1);\nconst changeAgeAndName = (x = { ...person }) => {\n  x.age += 1;\n  x.name = 'Sarah';\n};\n\nchangeAge(person);\nchangeAgeAndName();\n\nconsole.log(person);\n```",
+      "question_type": "mcq",
+      "difficulty": "advanced",
+      "explanation": "changeAge(person) mutates the original person object (age becomes 22). changeAgeAndName() is called with no argument, so it uses a new object copy from person, not affecting the original.",
+      "hint": "When does a default parameter create a new object vs. using the passed argument?",
+      "tags": ["default-parameters", "object-mutation", "spread", "references"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["functions", "objects", "spread-rest"],
+      "category_slugs": ["es6-features", "objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 116",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "{name: \"Sarah\", age: 22}",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "{name: \"Sarah\", age: 23}",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "{name: \"Lydia\", age: 22}",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "{name: \"Lydia\", age: 23}",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-117",
+      "question_text": "Which of the following options will return 6?\n\n```javascript\nfunction sumValues(x, y, z) {\n  return x + y + z;\n}\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "The spread operator ... spreads array elements as individual arguments. sumValues(...[1,2,3]) passes 1,2,3 as separate arguments, summing to 6.",
+      "hint": "How do you pass array elements as individual arguments?",
+      "tags": ["spread-operator", "function-arguments"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["spread-rest", "functions"],
+      "category_slugs": ["es6-features"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 117",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "sumValues([...1, 2, 3])",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "sumValues([...[1, 2, 3]])",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "sumValues(...[1, 2, 3])",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "sumValues([1, 2, 3])",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-118",
+      "question_text": "What is the output of the following code?\n\n```javascript\nlet num = 1;\nconst list = ['🥳', '🤠', '🥰', '🤪'];\n\nconsole.log(list[(num += 1)]);\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "num += 1 increments num to 2, then the expression evaluates to 2. list[2] returns the element at index 2, which is '🥰'.",
+      "hint": "What is the value of the expression (num += 1)?",
+      "tags": ["assignment", "array-indexing", "operators"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["data-types", "array-methods"],
+      "category_slugs": ["javascript-core-concepts", "javascript-methods"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 118",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "🤠",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "🥰",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "SyntaxError",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "ReferenceError",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-119",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst person = {\n  firstName: 'Lydia',\n  lastName: 'Hallie',\n  pet: {\n    name: 'Mara',\n    breed: 'Dutch Tulip Hound',\n  },\n  getFullName() {\n    return `${this.firstName} ${this.lastName}`;\n  },\n};\n\nconsole.log(person.pet?.name);\nconsole.log(person.pet?.family?.name);\nconsole.log(person.getFullName?.());\nconsole.log(member.getLastName?.());\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Optional chaining (?.) short-circuits and returns undefined if the left side is nullish. person.pet exists, so pet.name returns 'Mara'. pet.family doesn't exist, so returns undefined. getFullName exists and is called. member doesn't exist, so ReferenceError.",
+      "hint": "How does optional chaining handle non-existent properties vs. non-existent variables?",
+      "tags": ["optional-chaining", "objects", "methods", "error-handling"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["objects", "error-handling"],
+      "category_slugs": ["es6-features", "objects-and-functions", "error-and-debugging"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 119",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "undefined undefined undefined undefined",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "Mara undefined Lydia Hallie ReferenceError",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "Mara null Lydia Hallie null",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "null ReferenceError null ReferenceError",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-120",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst groceries = ['banana', 'apple', 'peanuts'];\n\nif (groceries.indexOf('banana')) {\n  console.log('We have to buy bananas!');\n} else {\n  console.log(`We don't have to buy bananas!`);\n}\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "indexOf returns 0 when 'banana' is found at index 0. 0 is falsy, so the else block executes, logging 'We don't have to buy bananas!'",
+      "hint": "What does indexOf return when an item is at the beginning of an array?",
+      "tags": ["indexof", "array-methods", "truthy-falsy"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["array-methods"],
+      "category_slugs": ["javascript-methods"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 120",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "We have to buy bananas!",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "We don't have to buy bananas!",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "undefined",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "1",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-121",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst config = {\n  languages: [],\n  set language(lang) {\n    return this.languages.push(lang);\n  },\n};\n\nconsole.log(config.language);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "The language property is defined as a setter only, with no getter. Accessing it directly returns undefined, even though it can be used for assignment.",
+      "hint": "What happens when you access a property that only has a setter?",
+      "tags": ["getters", "setters", "accessors"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["objects"],
+      "category_slugs": ["objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 121",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "function language(lang) { this.languages.push(lang }",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "0",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "[]",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "undefined",
+          "is_correct": true
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-122",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst name = 'Lydia Hallie';\n\nconsole.log(!typeof name === 'object');\nconsole.log(!typeof name === 'string');\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "typeof name returns 'string'. !'string' (with ! operator) converts 'string' to boolean false. false === 'object' is false, false === 'string' is false. Both comparisons return false.",
+      "hint": "What is the precedence of the ! operator compared to ===?",
+      "tags": ["typeof", "logical-operators", "precedence"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["data-types", "type-coercion"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 122",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "false true",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "true false",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "false false",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "true true",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-123",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst add = x => y => z => {\n  console.log(x, y, z);\n  return x + y + z;\n};\n\nadd(4)(5)(6);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "This is a curried function. Each arrow function returns another function, capturing the outer x and y through closure. The innermost function has access to all three values.",
+      "hint": "How does closure work with nested arrow functions?",
+      "tags": ["closures", "currying", "arrow-functions"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["functions", "scope"],
+      "category_slugs": ["javascript-core-concepts", "objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 123",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "4 5 6",
+          "is_correct": true
+        },
+        {
+          "key": "B",
+          "text": "6 5 4",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "4 function function",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "undefined undefined 6",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-124",
+      "question_text": "What is the output of the following code?\n\n```javascript\nasync function* range(start, end) {\n  for (let i = start; i <= end; i++) {\n    yield Promise.resolve(i);\n  }\n}\n\n(async () => {\n  const gen = range(1, 3);\n  for await (const item of gen) {\n    console.log(item);\n  }\n})();\n```",
+      "question_type": "mcq",
+      "difficulty": "advanced",
+      "explanation": "This is an async generator. It yields promises. for await...of waits for each promise to resolve before logging the resolved value (1,2,3).",
+      "hint": "How does for await...of work with async generators?",
+      "tags": ["async-generators", "for-await-of", "promises"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["generators", "async-await", "promises"],
+      "category_slugs": ["es6-features", "async-javascript"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 124",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "Promise {1} Promise {2} Promise {3}",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "Promise {<pending>} Promise {<pending>} Promise {<pending>}",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "1 2 3",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "undefined undefined undefined",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-125",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst myFunc = ({ x, y, z }) => {\n  console.log(x, y, z);\n};\n\nmyFunc(1, 2, 3);\n```",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "The function expects a single object argument with properties x, y, z. Passing three separate numbers doesn't match the expected parameter, so x, y, z are undefined.",
+      "hint": "What happens when you pass arguments that don't match the destructuring pattern?",
+      "tags": ["destructuring", "function-parameters"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["destructuring", "functions"],
+      "category_slugs": ["es6-features"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 125",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "1 2 3",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "{1: 1} {2: 2} {3: 3}",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "{ 1: undefined } undefined undefined",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "undefined undefined undefined",
+          "is_correct": true
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-126",
+      "question_text": "What is the output of the following code?\n\n```javascript\nfunction getFine(speed, amount) {\n  const formattedSpeed = new Intl.NumberFormat('en-US', {\n    style: 'unit',\n    unit: 'mile-per-hour'\n  }).format(speed);\n\n  const formattedAmount = new Intl.NumberFormat('en-US', {\n    style: 'currency',\n    currency: 'USD'\n  }).format(amount);\n\n  return `The driver drove ${formattedSpeed} and has to pay ${formattedAmount}`;\n}\n\nconsole.log(getFine(130, 300))\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Intl.NumberFormat formats numbers according to locale. 130 as 'mile-per-hour' becomes '130 mph'. 300 as USD currency becomes '$300.00'.",
+      "hint": "What does Intl.NumberFormat do with different style options?",
+      "tags": ["intl", "number-format", "internationalization"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["string-methods"],
+      "category_slugs": ["javascript-methods"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 126",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "The driver drove 130 and has to pay 300",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "The driver drove 130 mph and has to pay $300.00",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "The driver drove undefined and has to pay undefined",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "The driver drove 130.00 and has to pay 300.00",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-127",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst spookyItems = ['👻', '🎃', '🕸'];\n({ item: spookyItems[3] } = { item: '💀' });\n\nconsole.log(spookyItems);\n```",
+      "question_type": "mcq",
+      "difficulty": "advanced",
+      "explanation": "This uses destructuring assignment to assign the value '💀' to spookyItems[3]. The parentheses are needed because {} at start of statement is treated as a block. This adds a new element at index 3.",
+      "hint": "How does destructuring assignment work with array elements?",
+      "tags": ["destructuring", "assignment", "arrays"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["destructuring"],
+      "category_slugs": ["es6-features"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 127",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "[\"👻\", \"🎃\", \"🕸\"]",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "[\"👻\", \"🎃\", \"🕸\", \"💀\"]",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "[\"👻\", \"🎃\", \"🕸\", { item: \"💀\" }]",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "[\"👻\", \"🎃\", \"🕸\", \"[object Object]\"]",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-128",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst name = 'Lydia Hallie';\nconst age = 21;\n\nconsole.log(Number.isNaN(name));\nconsole.log(Number.isNaN(age));\n\nconsole.log(isNaN(name));\nconsole.log(isNaN(age));\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Number.isNaN checks if the value is exactly NaN (type 'number' and value NaN). isNaN coerces the value to a number first, then checks if it's NaN. name coerces to NaN, so isNaN returns true.",
+      "hint": "What's the difference between Number.isNaN and global isNaN?",
+      "tags": ["isnan", "number-isnan", "type-coercion"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["data-types", "type-coercion"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 128",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "true false true false",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "true false false false",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "false false true false",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "false true false true",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-129",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst randomValue = 21;\n\nfunction getInfo() {\n  console.log(typeof randomValue);\n  const randomValue = 'Lydia Hallie';\n}\n\ngetInfo();\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Inside getInfo, there's a const declaration for randomValue. Due to the temporal dead zone, accessing randomValue before its declaration (even though there's an outer variable) throws a ReferenceError.",
+      "hint": "What happens when you have a variable with the same name in nested scopes?",
+      "tags": ["scope", "hoisting", "temporal-dead-zone", "const"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["hoisting", "scope"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 129",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "\"number\"",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "\"string\"",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "undefined",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "ReferenceError",
+          "is_correct": true
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-130",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst myPromise = Promise.resolve('Woah some cool data');\n\n(async () => {\n  try {\n    console.log(await myPromise);\n  } catch {\n    throw new Error(`Oops didn't work`);\n  } finally {\n    console.log('Oh finally!');\n  }\n})();\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "myPromise resolves successfully, so the try block logs the resolved value. No error occurs, so catch is skipped. The finally block always executes, logging 'Oh finally!'.",
+      "hint": "When does the finally block execute?",
+      "tags": ["promises", "async-await", "try-catch-finally"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["promises", "async-await", "error-handling"],
+      "category_slugs": ["async-javascript", "error-and-debugging"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 130",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "Woah some cool data",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "Oh finally!",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "Woah some cool data Oh finally!",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "Oops didn't work Oh finally!",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-131",
+      "question_text": "What is the output of the following code?\n\n```javascript\nconst emojis = ['🥑', ['✨', '✨', ['🍕', '🍕']]];\n\nconsole.log(emojis.flat(1));\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "flat(1) flattens one level deep. It concatenates the first-level nested array ['✨', '✨', ['🍕', '🍕']] into the main array, but leaves the second-level array intact.",
+      "hint": "How does the depth parameter in flat() work?",
+      "tags": ["array-methods", "flat", "es6"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["array-methods"],
+      "category_slugs": ["javascript-methods", "es6-features"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 131",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "['🥑', ['✨', '✨', ['🍕', '🍕']]]",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "['🥑', '✨', '✨', ['🍕', '🍕']]",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "['🥑', ['✨', '✨', '🍕', '🍕']]",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "['🥑', '✨', '✨', '🍕', '🍕']",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-132",
+      "question_text": "What is the output of the following code?\n\n```javascript\nclass Counter {\n  constructor() {\n    this.count = 0;\n  }\n\n  increment() {\n    this.count++;\n  }\n}\n\nconst counterOne = new Counter();\ncounterOne.increment();\ncounterOne.increment();\n\nconst counterTwo = counterOne;\ncounterTwo.increment();\n\nconsole.log(counterOne.count);\n```",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "counterTwo is a reference to the same object as counterOne. All increments affect the same object. 2 increments on counterOne + 1 increment via counterTwo = 3 total.",
+      "hint": "Do counterOne and counterTwo reference the same object?",
+      "tags": ["classes", "references", "objects"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["classes", "objects"],
+      "category_slugs": ["objects-and-functions"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 132",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "0",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "1",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "2",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "3",
+          "is_correct": true
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "js-question-133-removed",
+      "question_text": "INCOMPLETE_QUESTION_REMOVED",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "Removed incomplete trailing record to keep seed file valid JSON.",
+      "hint": "",
+      "tags": [],
+      "learning_modes": ["guided"],
+      "topic_slugs": ["functions"],
+      "category_slugs": ["javascript-core-concepts"],
+      "source": {
+        "kind": "website",
+        "title": "JavaScript Questions",
+        "url": "https://github.com/lydiahallie/javascript-questions",
+        "section": "Question 133 (removed incomplete)",
+        "timestamp": null
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "Skipped",
+          "is_correct": true
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": ["Auto-generated placeholder due incomplete source JSON"]
+    }
+  ]
+}

--- a/tools/seed/questions/rendering-patterns/rendering-patterns-01.json
+++ b/tools/seed/questions/rendering-patterns/rendering-patterns-01.json
@@ -1,0 +1,283 @@
+{
+  "categories": [
+    {
+      "slug": "web-architecture",
+      "name": "Web Architecture",
+      "description": "Core strategies and patterns for building and delivering web applications."
+    }
+  ],
+  "topics": [
+    {
+      "slug": "rendering-fundamentals",
+      "name": "Rendering Fundamentals",
+      "category_slug": "web-architecture",
+      "description": "The basic process of converting code and data into viewable HTML."
+    },
+    {
+      "slug": "static-and-server-patterns",
+      "name": "Static and Server Rendering",
+      "category_slug": "web-architecture",
+      "description": "Strategies involving pre-built files and server-side generation."
+    },
+    {
+      "slug": "performance-and-hydration",
+      "name": "Performance and Hydration",
+      "category_slug": "web-architecture",
+      "description": "Optimizing user experience through efficient JavaScript execution and loading."
+    }
+  ],
+  "questions": [
+    {
+      "external_ref": "fireship-rendering-def-1",
+      "question_text": "What is the technical definition of 'rendering' in the context of web development?",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "According to the source, rendering is the specific process of turning data and code into HTML that the end user can see.",
+      "hint": "Think about the transformation from code to what the user sees.",
+      "tags": ["basics", "rendering"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["rendering-fundamentals"],
+      "category_slugs": ["web-architecture"],
+      "source": {
+        "kind": "video",
+        "title": "10 Rendering Patterns for Web Apps",
+        "url": null,
+        "section": "What is a rendering pattern",
+        "timestamp": "00:48"
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "The process of uploading files to a storage bucket.",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "Turning data and code into HTML for the end user.",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "The execution of JavaScript within the browser console.",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "Pointing a domain name to a server IP address.",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "fireship-static-drawback-1",
+      "question_text": "What is the primary drawback of using a traditional static website rendering paradigm?",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "Static sites are not suitable for websites where data changes often because they lack the ability to handle dynamic data without full rebuilds.",
+      "hint": "Consider sites with frequently updated information.",
+      "tags": ["static-sites"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["static-and-server-patterns"],
+      "category_slugs": ["web-architecture"],
+      "source": {
+        "kind": "video",
+        "title": "10 Rendering Patterns for Web Apps",
+        "url": null,
+        "section": "Static Website",
+        "timestamp": "01:25"
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "They are expensive to host in storage buckets.",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "They cannot be programmatically built using frameworks.",
+          "is_correct": false
+        },
+        {
+          "key": "C",
+          "text": "They are not ideal for websites where data changes frequently.",
+          "is_correct": true
+        },
+        {
+          "key": "D",
+          "text": "They require a full server-side runtime like Django.",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "fireship-spa-disadvantages-1",
+      "question_text": "Which two factors are identified as significant disadvantages of the Single Page Application (SPA) paradigm?",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "SPAs require a large JavaScript bundle that slows initial loads and can cause SEO issues because search engines struggle with dynamic content routes.",
+      "hint": "Think about bundle size and search engine visibility.",
+      "tags": ["spa", "performance", "seo"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["performance-and-hydration"],
+      "category_slugs": ["web-architecture"],
+      "source": {
+        "kind": "video",
+        "title": "10 Rendering Patterns for Web Apps",
+        "url": null,
+        "section": "Single Page Application",
+        "timestamp": "03:55"
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "High server costs and lack of routing support.",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "Slow initial page loads and difficulty with SEO.",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "Requirement for full page reloads and clunky UI.",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "Inability to fetch data via HTTP requests.",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "fireship-isr-concept-1",
+      "question_text": "How does Incremental Static Regeneration (ISR) handle dynamic data differently than a standard static site?",
+      "question_type": "short_answer",
+      "difficulty": "advanced",
+      "explanation": "ISR allows developers to deploy a static site but rebuild individual pages on the fly on the server when a cache is invalidated based on specific rules (like time).",
+      "hint": "Focus on the 'incremental' and 'on the fly' aspects.",
+      "tags": ["isr", "nextjs"],
+      "learning_modes": ["guided", "free-style", "custom"],
+      "topic_slugs": ["static-and-server-patterns"],
+      "category_slugs": ["web-architecture"],
+      "source": {
+        "kind": "video",
+        "title": "10 Rendering Patterns for Web Apps",
+        "url": null,
+        "section": "ISR",
+        "timestamp": "05:40"
+      },
+      "choices": [],
+      "answer_text": "ISR allows for rebuilding individual static pages on the fly when the cache is invalidated, enabling dynamic data updates without a full site redeploy.",
+      "validation_notes": []
+    },
+    {
+      "external_ref": "fireship-islands-architecture-1",
+      "question_text": "What is the key advantage of the Islands Architecture, as used by frameworks like Astro?",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Islands architecture starts with static HTML and only hydrates specific interactive components, which means it may ship zero JavaScript to the client for non-interactive pages.",
+      "hint": "Consider what happens if a page has no interactive parts.",
+      "tags": ["islands-architecture", "performance"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["performance-and-hydration"],
+      "category_slugs": ["web-architecture"],
+      "source": {
+        "kind": "video",
+        "title": "10 Rendering Patterns for Web Apps",
+        "url": null,
+        "section": "Islands Architecture",
+        "timestamp": "07:15"
+      },
+      "choices": [
+        {
+          "key": "A",
+          "text": "It requires the entire page to be hydrated at once.",
+          "is_correct": false
+        },
+        {
+          "key": "B",
+          "text": "It can ship zero JavaScript to the client for purely static pages.",
+          "is_correct": true
+        },
+        {
+          "key": "C",
+          "text": "It eliminates the need for any HTML on the server.",
+          "is_correct": false
+        },
+        {
+          "key": "D",
+          "text": "It forces all components to be interactive by default.",
+          "is_correct": false
+        }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    }
+  ],
+  "learning_cards": [
+    {
+      "external_ref": "fireship-card-jamstack",
+      "title": "Jamstack & SSG",
+      "front": "What defines a 'Jamstack' site in the context of Static Site Generation (SSG)?",
+      "back": "HTML is rendered in advance and uploaded to a static host, but it hydrates to JavaScript after the initial page load to provide an app-like experience.",
+      "difficulty": "intermediate",
+      "topic_slugs": ["static-and-server-patterns"],
+      "category_slugs": ["web-architecture"],
+      "learning_modes": ["guided"],
+      "source": {
+        "kind": "video",
+        "title": "10 Rendering Patterns for Web Apps",
+        "url": null,
+        "section": "SSG",
+        "timestamp": "05:10"
+      },
+      "validation_notes": []
+    },
+    {
+      "external_ref": "fireship-card-resumability",
+      "title": "Resumability (Quick)",
+      "front": "How does the Resumability paradigm (Quick framework) differ from traditional hydration?",
+      "back": "It serializes the website, data, and event listeners into HTML. JavaScript is broken into tiny chunks and lazy-loaded, avoiding the standard hydration process entirely.",
+      "difficulty": "advanced",
+      "topic_slugs": ["performance-and-hydration"],
+      "category_slugs": ["web-architecture"],
+      "learning_modes": ["guided", "custom"],
+      "source": {
+        "kind": "video",
+        "title": "10 Rendering Patterns for Web Apps",
+        "url": null,
+        "section": "Resumability",
+        "timestamp": "08:15"
+      },
+      "validation_notes": []
+    }
+  ],
+  "relations": {
+    "questions_topics": [
+      { "question_external_ref": "fireship-rendering-def-1", "topic_slug": "rendering-fundamentals" },
+      { "question_external_ref": "fireship-static-drawback-1", "topic_slug": "static-and-server-patterns" },
+      { "question_external_ref": "fireship-spa-disadvantages-1", "topic_slug": "performance-and-hydration" },
+      { "question_external_ref": "fireship-isr-concept-1", "topic_slug": "static-and-server-patterns" },
+      { "question_external_ref": "fireship-islands-architecture-1", "topic_slug": "performance-and-hydration" }
+    ],
+    "card_categories": [
+      { "card_external_ref": "fireship-card-jamstack", "category_slug": "web-architecture" },
+      { "card_external_ref": "fireship-card-resumability", "category_slug": "web-architecture" }
+    ],
+    "plan_questions": []
+  },
+  "quality_report": {
+    "total_sources_used": 1,
+    "total_questions_extracted": 5,
+    "duplicates_removed": 0,
+    "low_confidence_items": []
+  }
+}

--- a/tools/seed/questions/rendering-patterns/rendering-patterns-02.json
+++ b/tools/seed/questions/rendering-patterns/rendering-patterns-02.json
@@ -1,0 +1,195 @@
+{
+  "categories": [
+    {
+      "slug": "web-architecture",
+      "name": "Web Architecture",
+      "description": "Core strategies and patterns for building and delivering web applications."
+    }
+  ],
+  "topics": [
+    {
+      "slug": "rendering-fundamentals",
+      "name": "Rendering Fundamentals",
+      "category_slug": "web-architecture",
+      "description": "The basic process of converting code and data into viewable HTML."
+    },
+    {
+      "slug": "static-and-server-patterns",
+      "name": "Static and Server Rendering",
+      "category_slug": "web-architecture",
+      "description": "Strategies involving pre-built files and server-side generation."
+    },
+    {
+      "slug": "performance-and-hydration",
+      "name": "Performance and Hydration",
+      "category_slug": "web-architecture",
+      "description": "Optimizing user experience through efficient JavaScript execution and loading."
+    }
+  ],
+  "questions": [
+    {
+      "external_ref": "fireship-mpa-benefit-1",
+      "question_text": "What was the primary reason web development moved from static websites to Multi-Page Applications (MPAs)?",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "Multi-Page Applications were developed because websites needed to be more dynamic, allowing the appearance to change whenever the underlying data changes on the server.",
+      "hint": "Think about the need for dynamic data.",
+      "tags": ["mpa", "history"],
+      "learning_modes": ["guided"],
+      "topic_slugs": ["static-and-server-patterns"],
+      "category_slugs": ["web-architecture"],
+      "source": {
+        "kind": "video",
+        "title": "10 Rendering Patterns for Web Apps",
+        "url": null,
+        "section": "Multi-page applications",
+        "timestamp": "02:10"
+      },
+      "choices": [
+        { "key": "A", "text": "To eliminate the need for server-side code.", "is_correct": false },
+        { "key": "B", "text": "To allow the website to change dynamically when underlying data changes.", "is_correct": true },
+        { "key": "C", "text": "To provide an app-like experience with zero page reloads.", "is_correct": false },
+        { "key": "D", "text": "To make websites compatible with the first iPhone.", "is_correct": false }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "fireship-spa-mechanism-1",
+      "question_text": "In the Single Page Application (SPA) paradigm, how is the user interface typically rendered after the initial shell is loaded?",
+      "question_type": "short_answer",
+      "difficulty": "intermediate",
+      "explanation": "An SPA starts with one HTML page as a shell, then executes JavaScript in the browser to render the UI and fetch data with additional HTTP requests.",
+      "hint": "What executes in the browser to build the page?",
+      "tags": ["spa", "client-side-rendering"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["performance-and-hydration"],
+      "category_slugs": ["web-architecture"],
+      "source": {
+        "kind": "video",
+        "title": "10 Rendering Patterns for Web Apps",
+        "url": null,
+        "section": "Single Page Application",
+        "timestamp": "03:20"
+      },
+      "choices": [],
+      "answer_text": "By executing JavaScript in the browser to render the UI and fetching data via additional HTTP requests.",
+      "validation_notes": []
+    },
+    {
+      "external_ref": "fireship-ssr-definition-1",
+      "question_text": "What defines the 'Best of Both Worlds' approach in modern Server-Side Rendering (SSR)?",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Modern SSR renders the initial page load dynamically on the server for speed and SEO, then 'hydrates' to client-side JavaScript to provide a smooth SPA experience.",
+      "hint": "It combines server-side initial load with client-side interactivity.",
+      "tags": ["ssr", "hydration"],
+      "learning_modes": ["guided"],
+      "topic_slugs": ["static-and-server-patterns"],
+      "category_slugs": ["web-architecture"],
+      "source": {
+        "kind": "video",
+        "title": "10 Rendering Patterns for Web Apps",
+        "url": null,
+        "section": "SSR",
+        "timestamp": "04:30"
+      },
+      "choices": [
+        { "key": "A", "text": "Rendering everything in the browser first, then backing it up to a server.", "is_correct": false },
+        { "key": "B", "text": "Using only static HTML with no JavaScript allowed.", "is_correct": false },
+        { "key": "C", "text": "Server-side rendering for the initial load, followed by client-side hydration for an app-like experience.", "is_correct": true },
+        { "key": "D", "text": "Generating thousands of static files and never using a server again.", "is_correct": false }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "fireship-hydration-problem-1",
+      "question_text": "What user experience issue can occur during the 'hydration' process on a large website?",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "During hydration, the app might feel 'frozen' because the JavaScript is busy executing to take over the rendering process, making the page non-interactive for a short time.",
+      "hint": "Think about the app's responsiveness while JavaScript is loading.",
+      "tags": ["performance", "hydration"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["performance-and-hydration"],
+      "category_slugs": ["web-architecture"],
+      "source": {
+        "kind": "video",
+        "title": "10 Rendering Patterns for Web Apps",
+        "url": null,
+        "section": "Partial Hydration",
+        "timestamp": "06:30"
+      },
+      "choices": [
+        { "key": "A", "text": "The page colors might revert to black and white.", "is_correct": false },
+        { "key": "B", "text": "The website might feel frozen while JavaScript executes to take over the rendering.", "is_correct": true },
+        { "key": "C", "text": "Search engines will be unable to find the homepage.", "is_correct": false },
+        { "key": "D", "text": "The server will crash due to too many requests.", "is_correct": false }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "fireship-streaming-ssr-1",
+      "question_text": "How does Streaming SSR improve performance compared to traditional SSR?",
+      "question_type": "short_answer",
+      "difficulty": "advanced",
+      "explanation": "Streaming SSR allows the server to render and send content concurrently in multiple chunks rather than waiting to send everything all at once, making the UI interactive faster.",
+      "hint": "It involves breaking the response into chunks.",
+      "tags": ["streaming", "ssr", "react-server-components"],
+      "learning_modes": ["guided", "custom"],
+      "topic_slugs": ["performance-and-hydration"],
+      "category_slugs": ["web-architecture"],
+      "source": {
+        "kind": "video",
+        "title": "10 Rendering Patterns for Web Apps",
+        "url": null,
+        "section": "Streaming SSR",
+        "timestamp": "07:55"
+      },
+      "choices": [],
+      "answer_text": "It renders server-side content concurrently in multiple chunks instead of all at once, allowing the UI to become interactive faster.",
+      "validation_notes": []
+    }
+  ],
+  "learning_cards": [
+    {
+      "external_ref": "fireship-card-resumability-v2",
+      "title": "Resumability Mechanism",
+      "front": "How does 'Resumability' in the Quick framework avoid the hydration problem?",
+      "back": "It serializes the website, data, and event listeners directly into the HTML. JavaScript is broken into tiny chunks that are lazy-loaded only when needed, meaning no hydration phase is required.",
+      "difficulty": "advanced",
+      "topic_slugs": ["performance-and-hydration"],
+      "category_slugs": ["web-architecture"],
+      "learning_modes": ["custom"],
+      "source": {
+        "kind": "video",
+        "title": "10 Rendering Patterns for Web Apps",
+        "url": null,
+        "section": "Resumability",
+        "timestamp": "08:25"
+      },
+      "validation_notes": []
+    }
+  ],
+  "relations": {
+    "questions_topics": [
+      { "question_external_ref": "fireship-mpa-benefit-1", "topic_slug": "static-and-server-patterns" },
+      { "question_external_ref": "fireship-spa-mechanism-1", "topic_slug": "performance-and-hydration" },
+      { "question_external_ref": "fireship-ssr-definition-1", "topic_slug": "static-and-server-patterns" },
+      { "question_external_ref": "fireship-hydration-problem-1", "topic_slug": "performance-and-hydration" },
+      { "question_external_ref": "fireship-streaming-ssr-1", "topic_slug": "performance-and-hydration" }
+    ],
+    "card_categories": [
+      { "card_external_ref": "fireship-card-resumability-v2", "category_slug": "web-architecture" }
+    ],
+    "plan_questions": []
+  },
+  "quality_report": {
+    "total_sources_used": 1,
+    "total_questions_extracted": 5,
+    "duplicates_removed": 0,
+    "low_confidence_items": []
+  }
+}

--- a/tools/seed/questions/rendering-patterns/rendering-patterns-03.json
+++ b/tools/seed/questions/rendering-patterns/rendering-patterns-03.json
@@ -1,0 +1,208 @@
+{
+  "categories": [
+    {
+      "slug": "web-architecture",
+      "name": "Web Architecture",
+      "description": "Core strategies and patterns for building and delivering web applications."
+    }
+  ],
+  "topics": [
+    {
+      "slug": "static-and-server-patterns",
+      "name": "Static and Server Rendering",
+      "category_slug": "web-architecture",
+      "description": "Strategies involving pre-built files and server-side generation."
+    },
+    {
+      "slug": "performance-and-hydration",
+      "name": "Performance and Hydration",
+      "category_slug": "web-architecture",
+      "description": "Optimizing user experience through efficient JavaScript execution and loading."
+    }
+  ],
+  "questions": [
+    {
+      "external_ref": "fireship-jamstack-ssg-1",
+      "question_text": "What are the primary benefits of the Jamstack (SSG) approach compared to standard SSR?",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "Jamstack/SSG offers the low-cost hosting and simplicity of a static site because files are pre-rendered, while still providing an app-like experience via hydration.",
+      "hint": "Focus on hosting costs and simplicity.",
+      "tags": ["jamstack", "ssg", "hosting"],
+      "learning_modes": ["guided"],
+      "topic_slugs": ["static-and-server-patterns"],
+      "category_slugs": ["web-architecture"],
+      "source": {
+        "kind": "video",
+        "title": "10 Rendering Patterns for Web Apps",
+        "url": null,
+        "section": "SSG",
+        "timestamp": "05:15"
+      },
+      "choices": [
+        { "key": "A", "text": "It eliminates the need for any client-side JavaScript.", "is_correct": false },
+        { "key": "B", "text": "It provides low-cost hosting and simplicity while maintaining an app-like experience.", "is_correct": true },
+        { "key": "C", "text": "It allows for real-time data updates without any redeployments.", "is_correct": false },
+        { "key": "D", "text": "It is faster than standard static sites because it skips the storage bucket.", "is_correct": false }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "fireship-isr-hosting-complexity",
+      "question_text": "What is considered a significant barrier or drawback to implementing Incremental Static Regeneration (ISR)?",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "ISR is complex to set up manually, often requiring a specific host like Vercel that supports the pattern out of the box.",
+      "hint": "Think about the effort required for self-hosting.",
+      "tags": ["isr", "devops"],
+      "learning_modes": ["guided"],
+      "topic_slugs": ["static-and-server-patterns"],
+      "category_slugs": ["web-architecture"],
+      "source": {
+        "kind": "video",
+        "title": "10 Rendering Patterns for Web Apps",
+        "url": null,
+        "section": "ISR",
+        "timestamp": "06:10"
+      },
+      "choices": [
+        { "key": "A", "text": "It makes the website significantly slower than a standard MPA.", "is_correct": false },
+        { "key": "B", "text": "It is more complex to set up and typically requires specialized hosting support.", "is_correct": true },
+        { "key": "C", "text": "It cannot handle any dynamic data or cache invalidation.", "is_correct": false },
+        { "key": "D", "text": "It requires a full site redeploy for every small change in data.", "is_correct": false }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "fireship-partial-hydration-trigger",
+      "question_text": "In the context of partial hydration, what is a common strategy used to make a component like a 'highly interactive footer' interactive?",
+      "question_type": "short_answer",
+      "difficulty": "intermediate",
+      "explanation": "Partial hydration allows developers to wait until a user scrolls down to a component before making it interactive, reducing the initial JavaScript execution load.",
+      "hint": "Consider the user's physical interaction with the page.",
+      "tags": ["performance", "lazy-loading"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["performance-and-hydration"],
+      "category_slugs": ["web-architecture"],
+      "source": {
+        "kind": "video",
+        "title": "10 Rendering Patterns for Web Apps",
+        "url": null,
+        "section": "Partial Hydration",
+        "timestamp": "06:55"
+      },
+      "choices": [],
+      "answer_text": "Waiting until the user scrolls down to the component before making it interactive.",
+      "validation_notes": []
+    },
+    {
+      "external_ref": "fireship-spa-routing-mechanism",
+      "question_text": "How do routes function in a Single Page Application (SPA) compared to a Multi-Page Application (MPA)?",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "In an SPA, routes do not point to a server; they are updated locally by JavaScript in the browser to make the transition feel instantaneous.",
+      "hint": "Does the browser ask the server for a new page on every route change?",
+      "tags": ["spa", "routing"],
+      "learning_modes": ["guided"],
+      "topic_slugs": ["performance-and-hydration"],
+      "category_slugs": ["web-architecture"],
+      "source": {
+        "kind": "video",
+        "title": "10 Rendering Patterns for Web Apps",
+        "url": null,
+        "section": "Single Page Application",
+        "timestamp": "03:35"
+      },
+      "choices": [
+        { "key": "A", "text": "Each route points to a unique dynamically generated HTML file on the server.", "is_correct": false },
+        { "key": "B", "text": "Routes are purely cosmetic and cannot fetch additional data.", "is_correct": false },
+        { "key": "C", "text": "Routes are updated by JavaScript in the browser and do not point to a server.", "is_correct": true },
+        { "key": "D", "text": "SPAs only support a single URL and cannot have multiple routes.", "is_correct": false }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "fireship-meta-framework-role",
+      "question_text": "Which type of framework is responsible for implementing the 'Best of Both Worlds' approach by handling both server-side rendering and client-side hydration?",
+      "question_type": "short_answer",
+      "difficulty": "beginner",
+      "explanation": "Meta-frameworks like Next.js, Nuxt, and SvelteKit handle the initial server-side request and then hydrate to client-side JavaScript.",
+      "hint": "Examples include Next.js and Nuxt.",
+      "tags": ["frameworks", "ssr"],
+      "learning_modes": ["guided"],
+      "topic_slugs": ["static-and-server-patterns"],
+      "category_slugs": ["web-architecture"],
+      "source": {
+        "kind": "video",
+        "title": "10 Rendering Patterns for Web Apps",
+        "url": null,
+        "section": "SSR",
+        "timestamp": "04:35"
+      },
+      "choices": [],
+      "answer_text": "Meta-frameworks (e.g., Next.js, Nuxt, SvelteKit).",
+      "validation_notes": []
+    }
+  ],
+  "learning_cards": [
+    {
+      "external_ref": "fireship-card-rendering-def",
+      "title": "Rendering Definition",
+      "front": "What is the core definition of 'rendering' in web development?",
+      "back": "The process of turning data and code into HTML that can be seen by the end user.",
+      "difficulty": "beginner",
+      "topic_slugs": ["rendering-fundamentals"],
+      "category_slugs": ["web-architecture"],
+      "learning_modes": ["guided"],
+      "source": {
+        "kind": "video",
+        "title": "10 Rendering Patterns for Web Apps",
+        "url": null,
+        "section": "What is a rendering pattern",
+        "timestamp": "00:48"
+      },
+      "validation_notes": []
+    },
+    {
+      "external_ref": "fireship-card-island-static",
+      "title": "Islands: Zero JS",
+      "front": "What happens in an Islands Architecture if a page has no interactive components?",
+      "back": "No JavaScript is ever shipped to the client, even if the UI was built with a framework like React.",
+      "difficulty": "intermediate",
+      "topic_slugs": ["performance-and-hydration"],
+      "category_slugs": ["web-architecture"],
+      "learning_modes": ["guided"],
+      "source": {
+        "kind": "video",
+        "title": "10 Rendering Patterns for Web Apps",
+        "url": null,
+        "section": "Islands Architecture",
+        "timestamp": "07:35"
+      },
+      "validation_notes": []
+    }
+  ],
+  "relations": {
+    "questions_topics": [
+      { "question_external_ref": "fireship-jamstack-ssg-1", "topic_slug": "static-and-server-patterns" },
+      { "question_external_ref": "fireship-isr-hosting-complexity", "topic_slug": "static-and-server-patterns" },
+      { "question_external_ref": "fireship-partial-hydration-trigger", "topic_slug": "performance-and-hydration" },
+      { "question_external_ref": "fireship-spa-routing-mechanism", "topic_slug": "performance-and-hydration" },
+      { "question_external_ref": "fireship-meta-framework-role", "topic_slug": "static-and-server-patterns" }
+    ],
+    "card_categories": [
+      { "card_external_ref": "fireship-card-rendering-def", "category_slug": "web-architecture" },
+      { "card_external_ref": "fireship-card-island-static", "category_slug": "web-architecture" }
+    ],
+    "plan_questions": []
+  },
+  "quality_report": {
+    "total_sources_used": 1,
+    "total_questions_extracted": 5,
+    "duplicates_removed": 0,
+    "low_confidence_items": []
+  }
+}

--- a/tools/seed/questions/swr/swr.json
+++ b/tools/seed/questions/swr/swr.json
@@ -1,0 +1,264 @@
+{
+  "categories": [
+    {
+      "slug": "react-development",
+      "name": "React Development",
+      "description": "Building interactive user interfaces using React hooks and ecosystem tools."
+    }
+  ],
+  "topics": [
+    {
+      "slug": "swr-fundamentals",
+      "name": "SWR Fundamentals",
+      "category_slug": "react-development",
+      "description": "Core concepts of the stale-while-revalidate fetching strategy."
+    },
+    {
+      "slug": "data-fetching-patterns",
+      "name": "Data Fetching Patterns",
+      "category_slug": "react-development",
+      "description": "Strategies for remote data retrieval, caching, and synchronization."
+    },
+    {
+      "slug": "advanced-swr-features",
+      "name": "Advanced SWR Features",
+      "category_slug": "react-development",
+      "description": "Pagination, dependent fetching, and local mutations."
+    }
+  ],
+  "questions": [
+    {
+      "external_ref": "smashing-swr-definition",
+      "question_text": "What does the initialism 'SWR' stand for in the context of the Vercel React Hooks library?",
+      "question_type": "mcq",
+      "difficulty": "beginner",
+      "explanation": "SWR stands for stale-while-revalidate, a strategy that first returns data from the cache (stale), then sends the fetch request (revalidate), and finally provides up-to-date data.",
+      "hint": "It describes a three-step caching strategy.",
+      "tags": ["basics", "caching"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["swr-fundamentals"],
+      "category_slugs": ["react-development"],
+      "source": {
+        "kind": "website",
+        "title": "An Introduction To SWR: React Hooks For Remote Data Fetching",
+        "url": null,
+        "section": "What Is SWR?",
+        "timestamp": null
+      },
+      "choices": [
+        { "key": "A", "text": "Static-Web-Rendering", "is_correct": false },
+        { "key": "B", "text": "Stale-While-Revalidate", "is_correct": true },
+        { "key": "C", "text": "Standard-Web-Request", "is_correct": false },
+        { "key": "D", "text": "Sync-With-Remote", "is_correct": false }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "smashing-swr-vs-axios",
+      "question_text": "What is the primary advantage of using SWR over standard HTTP clients like Axios or the Fetch API?",
+      "question_type": "mcq",
+      "difficulty": "intermediate",
+      "explanation": "While Axios and Fetch handle requests and responses, SWR provides built-in features like caching, pagination, scroll position recovery, and dependent fetching out of the box.",
+      "hint": "Think about features that go beyond simple request/response handling.",
+      "tags": ["comparison", "features"],
+      "learning_modes": ["guided", "free-style"],
+      "topic_slugs": ["data-fetching-patterns"],
+      "category_slugs": ["react-development"],
+      "source": {
+        "kind": "website",
+        "title": "An Introduction To SWR: React Hooks For Remote Data Fetching",
+        "url": null,
+        "section": "Comparison With Fetch And Axios",
+        "timestamp": null
+      },
+      "choices": [
+        { "key": "A", "text": "SWR is faster at the initial TCP handshake.", "is_correct": false },
+        { "key": "B", "text": "SWR replaces the need for an API backend.", "is_correct": false },
+        { "key": "C", "text": "SWR provides automatic caching and revalidation features.", "is_correct": true },
+        { "key": "D", "text": "SWR is the only library that supports JSON transformation.", "is_correct": false }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "smashing-swr-config-global",
+      "question_text": "Which component is used to configure SWR globally so that a 'fetcher' function can be shared across the entire application?",
+      "question_type": "short_answer",
+      "difficulty": "beginner",
+      "explanation": "SWRConfig is a provider component that allows child components to inherit global configuration, such as a common fetcher function.",
+      "hint": "It is a provider wrapper mentioned for 'Configuring SWR Globally'.",
+      "tags": ["configuration", "hooks"],
+      "learning_modes": ["guided"],
+      "topic_slugs": ["swr-fundamentals"],
+      "category_slugs": ["react-development"],
+      "source": {
+        "kind": "website",
+        "title": "An Introduction To SWR: React Hooks For Remote Data Fetching",
+        "url": null,
+        "section": "Configuring SWR Globally",
+        "timestamp": null
+      },
+      "choices": [],
+      "answer_text": "SWRConfig",
+      "validation_notes": []
+    },
+    {
+      "external_ref": "smashing-swr-dependent-fetching",
+      "question_text": "What performance issue does SWR's 'Dependent Fetching' feature help avoid when dealing with relational data?",
+      "question_type": "mcq",
+      "difficulty": "advanced",
+      "explanation": "Dependent fetching allows SWR to fetch data that depends on another request while specifically avoiding 'waterfalls' (unnecessary sequential delays).",
+      "hint": "It is a common term for sequential network requests that slow down performance.",
+      "tags": ["performance", "relational-data"],
+      "learning_modes": ["guided", "custom"],
+      "topic_slugs": ["advanced-swr-features"],
+      "category_slugs": ["react-development"],
+      "source": {
+        "kind": "website",
+        "title": "An Introduction To SWR: React Hooks For Remote Data Fetching",
+        "url": null,
+        "section": "Dependent Fetching",
+        "timestamp": null
+      },
+      "choices": [
+        { "key": "A", "text": "Race conditions", "is_correct": false },
+        { "key": "B", "text": "Waterfalls", "is_correct": true },
+        { "key": "C", "text": "Memory leaks", "is_correct": false },
+        { "key": "D", "text": "Over-fetching", "is_correct": false }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "smashing-swr-focus-revalidation",
+      "question_text": "True or False: By default, SWR automatically revalidates (updates) data when a user re-focuses the page or switches back to the tab.",
+      "question_type": "true_false",
+      "difficulty": "intermediate",
+      "explanation": "Focus revalidation is a built-in feature of SWR that is enabled by default to keep data synchronized when the user returns to the page.",
+      "hint": "Check the default status of 'Focus Revalidation'.",
+      "tags": ["synchronization", "ux"],
+      "learning_modes": ["guided"],
+      "topic_slugs": ["swr-fundamentals"],
+      "category_slugs": ["react-development"],
+      "source": {
+        "kind": "website",
+        "title": "An Introduction To SWR: React Hooks For Remote Data Fetching",
+        "url": null,
+        "section": "Focus Revalidation",
+        "timestamp": null
+      },
+      "choices": [
+        { "key": "A", "text": "True", "is_correct": true },
+        { "key": "B", "text": "False", "is_correct": false }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    },
+    {
+      "external_ref": "smashing-swr-pages-args",
+      "question_text": "The useSWRPages hook receives four specific arguments for pagination. Which of the following is NOT one of them?",
+      "question_type": "mcq",
+      "difficulty": "advanced",
+      "explanation": "According to the source, useSWRPages receives: 1. The key of the request, 2. A function to fetch the data, 3. A function that takes the SWR object for the next page, and 4. An array of dependencies.",
+      "hint": "One of these is usually associated with useEffect but is also used here.",
+      "tags": ["pagination", "hooks"],
+      "learning_modes": ["custom"],
+      "topic_slugs": ["advanced-swr-features"],
+      "category_slugs": ["react-development"],
+      "source": {
+        "kind": "website",
+        "title": "An Introduction To SWR: React Hooks For Remote Data Fetching",
+        "url": null,
+        "section": "Paginate Our Data With useSWRPages",
+        "timestamp": null
+      },
+      "choices": [
+        { "key": "A", "text": "A request key", "is_correct": false },
+        { "key": "B", "text": "A function to fetch the data", "is_correct": false },
+        { "key": "C", "text": "An array of dependencies", "is_correct": false },
+        { "key": "D", "text": "A maximum page limit integer", "is_correct": true }
+      ],
+      "answer_text": null,
+      "validation_notes": []
+    }
+  ],
+  "learning_cards": [
+    {
+      "external_ref": "smashing-card-swr-steps",
+      "title": "The 3 Steps of SWR",
+      "front": "What are the three internal steps SWR handles for remote data fetching?",
+      "back": "1. Return data from cache (stale). 2. Send the fetch request (revalidate). 3. Return up-to-date data.",
+      "difficulty": "intermediate",
+      "topic_slugs": ["swr-fundamentals"],
+      "category_slugs": ["react-development"],
+      "learning_modes": ["guided"],
+      "source": {
+        "kind": "website",
+        "title": "An Introduction To SWR: React Hooks For Remote Data Fetching",
+        "url": null,
+        "section": "What Is SWR?",
+        "timestamp": null
+      },
+      "validation_notes": []
+    },
+    {
+      "external_ref": "smashing-card-local-mutation",
+      "title": "Local Mutation & Offline-First",
+      "front": "How does the 'Local Mutation' feature in SWR support an 'Offline-first' approach?",
+      "back": "It allows setting a temporary local state that updates the UI immediately while waiting for the remote revalidation to finish.",
+      "difficulty": "advanced",
+      "topic_slugs": ["advanced-swr-features"],
+      "category_slugs": ["react-development"],
+      "learning_modes": ["custom"],
+      "source": {
+        "kind": "website",
+        "title": "An Introduction To SWR: React Hooks For Remote Data Fetching",
+        "url": null,
+        "section": "Local Mutation",
+        "timestamp": null
+      },
+      "validation_notes": []
+    },
+    {
+      "external_ref": "smashing-card-backend-agnostic",
+      "title": "Backend Agnostic Meaning",
+      "front": "What does it mean that SWR is 'backend agnostic'?",
+      "back": "It can fetch data from any kind of API or database (REST, GraphQL, etc.) as long as a fetcher function is provided.",
+      "difficulty": "beginner",
+      "topic_slugs": ["swr-fundamentals"],
+      "category_slugs": ["react-development"],
+      "learning_modes": ["guided"],
+      "source": {
+        "kind": "website",
+        "title": "An Introduction To SWR: React Hooks For Remote Data Fetching",
+        "url": null,
+        "section": "What Is SWR? (Paragraph 3)",
+        "timestamp": null
+      },
+      "validation_notes": []
+    }
+  ],
+  "relations": {
+    "questions_topics": [
+      { "question_external_ref": "smashing-swr-definition", "topic_slug": "swr-fundamentals" },
+      { "question_external_ref": "smashing-swr-vs-axios", "topic_slug": "data-fetching-patterns" },
+      { "question_external_ref": "smashing-swr-config-global", "topic_slug": "swr-fundamentals" },
+      { "question_external_ref": "smashing-swr-dependent-fetching", "topic_slug": "advanced-swr-features" },
+      { "question_external_ref": "smashing-swr-focus-revalidation", "topic_slug": "swr-fundamentals" },
+      { "question_external_ref": "smashing-swr-pages-args", "topic_slug": "advanced-swr-features" }
+    ],
+    "card_categories": [
+      { "card_external_ref": "smashing-card-swr-steps", "category_slug": "react-development" },
+      { "card_external_ref": "smashing-card-local-mutation", "category_slug": "react-development" },
+      { "card_external_ref": "smashing-card-backend-agnostic", "category_slug": "react-development" }
+    ],
+    "plan_questions": []
+  },
+  "quality_report": {
+    "total_sources_used": 1,
+    "total_questions_extracted": 6,
+    "duplicates_removed": 0,
+    "low_confidence_items": []
+  }
+}

--- a/tools/seed/seed-all.mjs
+++ b/tools/seed/seed-all.mjs
@@ -1,0 +1,915 @@
+import { createClient } from "@supabase/supabase-js";
+import * as dotenv from "dotenv";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { dirname } from "path";
+
+dotenv.config({ path: ".env.local" });
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+    console.error("❌ Missing Supabase environment variables in .env.local");
+    process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+function toSeedQuestionType(rawType) {
+    const type = String(rawType || "").toLowerCase().trim();
+    if (type === "mcq" || type === "multiple-choice" || type === "multiple_select" || type === "multiple-select") {
+        return "multiple-choice";
+    }
+    if (type === "true_false" || type === "true-false") {
+        return "true-false";
+    }
+    // Normalize short/open-ended inputs to MCQ for this seeding flow.
+    if (type === "short_answer" || type === "short-answer" || type === "open-ended" || type === "open_ended") {
+        return "multiple-choice";
+    }
+    if (type === "code") {
+        return "code";
+    }
+    return "multiple-choice";
+}
+
+function toSeedDifficulty(rawDifficulty) {
+    const difficulty = String(rawDifficulty || "").toLowerCase().trim();
+    if (difficulty === "beginner" || difficulty === "intermediate" || difficulty === "advanced") {
+        return difficulty;
+    }
+    return "intermediate";
+}
+
+function normalizeOptions(question) {
+    const sourceOptions = Array.isArray(question.options) ? question.options : Array.isArray(question.choices) ? question.choices : [];
+    return sourceOptions.map((opt, index) => ({
+        id: opt?.id || opt?.key || String.fromCharCode(65 + index),
+        text: opt?.text || "",
+        isCorrect: Boolean(opt?.isCorrect ?? opt?.is_correct ?? false)
+    }));
+}
+
+function resolveCorrectAnswer(question, normalizedOptions) {
+    if (question.correct_answer) {
+        return question.correct_answer;
+    }
+
+    const correctOption = normalizedOptions.find(opt => opt.isCorrect);
+    if (correctOption) {
+        return correctOption.id;
+    }
+
+    if (question.answer_text) {
+        return question.answer_text;
+    }
+
+    return null;
+}
+
+function clampString(value, maxLen) {
+    const text = String(value || "");
+    return text.length > maxLen ? `${text.slice(0, maxLen - 1)}…` : text;
+}
+
+function buildSeedTitle(rawTitle, rawContent) {
+    const titleSource = String(rawTitle || "").trim();
+    const contentSource = String(rawContent || "").trim();
+    const firstLine = (titleSource || contentSource).split("\n").find(line => line.trim().length > 0) || "Untitled question";
+    return clampString(firstLine.trim(), 255);
+}
+
+function slugify(text) {
+    return String(text || "")
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "");
+}
+
+const CANONICAL_LEARNING_CARDS = [
+    {
+        key: "core",
+        title: "Core Technologies",
+        description: "HTML, CSS, JavaScript, TypeScript",
+        color: "#3B82F6",
+        icon: "layers",
+        order_index: 0
+    },
+    {
+        key: "framework",
+        title: "Framework Questions",
+        description: "React, Next.js, Vue, Angular, Svelte",
+        color: "#10B981",
+        icon: "layers",
+        order_index: 1
+    },
+    {
+        key: "problem",
+        title: "Problem Solving",
+        description: "Frontend coding challenges and algorithms",
+        color: "#F59E0B",
+        icon: "layers",
+        order_index: 2
+    },
+    {
+        key: "system",
+        title: "System Design",
+        description: "Frontend architecture patterns",
+        color: "#EF4444",
+        icon: "layers",
+        order_index: 3
+    }
+];
+
+const CANONICAL_CARD_TYPE_BY_KEY = {
+    core: "core-technologies",
+    framework: "framework-questions",
+    problem: "problem-solving",
+    system: "system-design"
+};
+
+function mapCategoryToCanonicalCardKey(category) {
+    const hint = `${category?.card_type || ""} ${category?.slug || ""} ${category?.name || ""}`.toLowerCase();
+
+    if (
+        hint.includes("framework") ||
+        hint.includes("react") ||
+        hint.includes("next") ||
+        hint.includes("vue") ||
+        hint.includes("angular") ||
+        hint.includes("svelte")
+    ) {
+        return "framework";
+    }
+
+    if (
+        hint.includes("problem") ||
+        hint.includes("algorithm") ||
+        hint.includes("coding") ||
+        hint.includes("challenge")
+    ) {
+        return "problem";
+    }
+
+    if (
+        hint.includes("system") ||
+        hint.includes("design") ||
+        hint.includes("architecture")
+    ) {
+        return "system";
+    }
+
+    return "core";
+}
+
+/**
+ * Generate plan metadata for spaced repetition architecture
+ * @param {number} planSequence - 1, 2, 3, or 4
+ * @returns {object} - { title, description, plan_type, sequence_index }
+ */
+function generatePlanMetadata(planSequence) {
+    const plans = {
+        1: {
+            title: "Initial",
+            description: "Start with core concepts and essential patterns across all four cards.",
+            plan_type: "initial",
+            sequence_index: 1,
+            new_question_count: 10,
+            review_question_count: 0
+        },
+        2: {
+            title: "Review",
+            description: "Mix new content with targeted review to deepen understanding.",
+            plan_type: "reinforcement",
+            sequence_index: 2,
+            new_question_count: 5,
+            review_question_count: 5
+        },
+        3: {
+            title: "Advanced",
+            description: "Challenge understanding with advanced scenarios and edge cases.",
+            plan_type: "advanced",
+            sequence_index: 3,
+            new_question_count: 4,
+            review_question_count: 8
+        },
+        4: {
+            title: "Maintenance",
+            description: "Maintain knowledge with spaced review and minimal new content.",
+            plan_type: "maintenance",
+            sequence_index: 4,
+            new_question_count: 2,
+            review_question_count: 8
+        }
+    };
+    return plans[planSequence] || plans[1];
+}
+
+/**
+ * Calculate display label for plan cards
+ * @param {number} newCount - number of new questions
+ * @param {number} reviewCount - number of review questions
+ * @returns {string} - e.g., "10 questions" or "5 new + 5 review"
+ */
+function getDisplayLabel(newCount, reviewCount) {
+    const total = newCount + reviewCount;
+    if (reviewCount === 0) {
+        return `${total} questions`;
+    }
+    return `${newCount} new + ${reviewCount} review`;
+}
+
+/**
+ * Group questions by difficulty tier
+ * @param {array} questions - array of question IDs
+ * @returns {object} - { easy: [], medium: [], hard: [] }
+ */
+function groupQuestionsByDifficulty(questions) {
+    // Simulate difficulty grouping based on index
+    // In production, this would be based on actual difficulty data
+    const third = Math.ceil(questions.length / 3);
+    return {
+        easy: questions.slice(0, third),
+        medium: questions.slice(third, 2 * third),
+        hard: questions.slice(2 * third)
+    };
+}
+
+async function insertFirstValidPayload(table, payloads) {
+    let lastError = null;
+    for (const basePayload of payloads) {
+        const payload = { ...basePayload };
+
+        while (true) {
+            const { data, error } = await supabase
+                .from(table)
+                .insert(payload)
+                .select("id")
+                .single();
+
+            if (!error && data?.id) {
+                return { data, error: null };
+            }
+
+            lastError = error;
+
+            const missingColumnMatch = String(error?.message || "").match(/Could not find the '([^']+)' column/);
+            if (!missingColumnMatch) {
+                break;
+            }
+
+            const missingColumn = missingColumnMatch[1];
+            if (!(missingColumn in payload)) {
+                break;
+            }
+
+            delete payload[missingColumn];
+        }
+    }
+
+    return { data: null, error: lastError };
+}
+
+function normalizeQuestion(question) {
+    const rawContent = question.content || question.question_text || question.title || "";
+    const title = buildSeedTitle(question.title || question.question_text || "", rawContent);
+    const content = rawContent;
+    const options = normalizeOptions(question);
+
+    return {
+        title,
+        content,
+        type: toSeedQuestionType(question.type || question.question_type),
+        difficulty: toSeedDifficulty(question.difficulty),
+        points: typeof question.points === "number" ? question.points : 1,
+        options,
+        correct_answer: resolveCorrectAnswer(question, options),
+        explanation: question.explanation || null,
+        cat_slug: question.cat_slug || question.category_slug || question.category_slugs?.[0] || null,
+        topic_slug: question.topic_slug || question.topic_slugs?.[0] || null,
+        tags: Array.isArray(question.tags) ? question.tags : null,
+        metadata: question.metadata || {
+            learning_modes: Array.isArray(question.learning_modes) ? question.learning_modes : [],
+            source: question.source || null,
+            external_ref: question.external_ref || null
+        },
+        resources: question.resources || (question.source ? [question.source] : null),
+        external_ref: question.external_ref || null
+    };
+}
+
+function writeFailedQuestionLog(failedQuestions) {
+    if (!failedQuestions.length) {
+        return;
+    }
+
+    const logsDir = path.join(__dirname, "logs");
+    if (!fs.existsSync(logsDir)) {
+        fs.mkdirSync(logsDir, { recursive: true });
+    }
+
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const logFilePath = path.join(logsDir, `failed-questions-${timestamp}.json`);
+    fs.writeFileSync(logFilePath, JSON.stringify({
+        created_at: new Date().toISOString(),
+        total_failed_questions: failedQuestions.length,
+        failed_questions: failedQuestions
+    }, null, 2));
+
+    console.log(`   📝 Failed question log written to ${path.relative(process.cwd(), logFilePath)}`);
+}
+
+// Load data from samples or fallback to starter-data.json
+function loadSeedData() {
+    const questionsDir = path.join(__dirname, "questions");
+    let mergedData = {
+        categories: [],
+        topics: [],
+        questions: []
+    };
+
+    // Check if questions directory exists with sample files
+    if (fs.existsSync(questionsDir)) {
+        console.log("📂 Found questions directory, loading sample files...");
+        const loadJsonFilesRecursive = (dir) => {
+            const files = fs.readdirSync(dir);
+            const jsonFiles = [];
+
+            for (const file of files) {
+                const filePath = path.join(dir, file);
+                const stat = fs.statSync(filePath);
+
+                if (stat.isDirectory()) {
+                    jsonFiles.push(...loadJsonFilesRecursive(filePath));
+                } else if (file.endsWith(".json")) {
+                    jsonFiles.push(filePath);
+                }
+            }
+            return jsonFiles;
+        };
+
+        const jsonFiles = loadJsonFilesRecursive(questionsDir).sort();
+        console.log(`   Found ${jsonFiles.length} sample file(s)`);
+
+        // Merge all sample files
+        for (const filePath of jsonFiles) {
+            try {
+                const sampleData = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+                console.log(`   ✓ Loaded ${path.relative(__dirname, filePath)}`);
+
+                // Merge categories (avoid duplicates by slug)
+                const existingSlugs = new Set(mergedData.categories.map(c => c.slug));
+                sampleData.categories?.forEach(cat => {
+                    if (!existingSlugs.has(cat.slug)) {
+                        mergedData.categories.push(cat);
+                        existingSlugs.add(cat.slug);
+                    }
+                });
+
+                // Merge topics (avoid duplicates by slug)
+                const existingTopicSlugs = new Set(mergedData.topics.map(t => t.slug));
+                sampleData.topics?.forEach(top => {
+                    if (!existingTopicSlugs.has(top.slug)) {
+                        mergedData.topics.push(top);
+                        existingTopicSlugs.add(top.slug);
+                    }
+                });
+
+                // Merge questions (avoid duplicates by external_ref)
+                const existingRefs = new Set(mergedData.questions.map(q => q.external_ref));
+                sampleData.questions?.forEach(q => {
+                    if (!existingRefs.has(q.external_ref)) {
+                        mergedData.questions.push(q);
+                        existingRefs.add(q.external_ref);
+                    }
+                });
+            } catch (err) {
+                console.error(`   ❌ Failed to load ${filePath}: ${err.message}`);
+            }
+        }
+
+        console.log(`📊 Merged data: ${mergedData.categories.length} categories, ${mergedData.topics.length} topics, ${mergedData.questions.length} questions\n`);
+        return mergedData;
+    } else {
+        // Fallback to starter-data.json
+        console.log("📂 No questions directory found, using starter-data.json...");
+        const starterPath = path.join(__dirname, "starter-data.json");
+        if (fs.existsSync(starterPath)) {
+            return JSON.parse(fs.readFileSync(starterPath, "utf-8"));
+        } else {
+            console.error("❌ No seed data found. Create questions/ directory with samples or starter-data.json");
+            process.exit(1);
+        }
+    }
+}
+
+const data = loadSeedData();
+
+async function clearTables() {
+    console.log("🗑️  Clearing tables...");
+
+    // Break category -> learning_card link first so card/category cleanup can proceed safely.
+    const { error: detachCategoryCardError } = await supabase
+        .from("categories")
+        .update({ learning_card_id: null })
+        .neq("id", "00000000-0000-0000-0000-000000000000");
+
+    if (detachCategoryCardError && !detachCategoryCardError.message.includes("does not exist")) {
+        console.warn(`   ⚠️  Failed detaching category card links: ${detachCategoryCardError.message}`);
+    }
+
+    const tables = [
+        "questions_topics",
+        "plan_questions",
+        "plan_cards",
+        "card_categories",
+        "questions",
+        "topics",
+        "categories",
+        "learning_cards",
+        "learning_plans"
+    ];
+    for (const table of tables) {
+        const { error } = await supabase.from(table).delete().neq("id", "00000000-0000-0000-0000-000000000000");
+        if (error && !error.message.includes("does not exist")) {
+            console.warn(`   ⚠️  Failed to clear ${table}: ${error.message}`);
+        }
+    }
+}
+
+async function seed() {
+    console.log("🚀 Starting comprehensive seeding...");
+
+    await clearTables();
+
+    // 1. Seed Categories
+    console.log("📁 Seeding Categories...");
+    const catMappings = {};
+    for (const cat of data.categories) {
+        const { data: record, error } = await supabase
+            .from("categories")
+            .upsert({
+                name: cat.name,
+                slug: cat.slug,
+                description: cat.description,
+                card_type: cat.card_type || "concept",
+                icon: cat.icon || "book-open",
+                color: cat.color || "#64748b",
+                order_index: typeof cat.order_index === "number" ? cat.order_index : 0
+            }, { onConflict: "slug" })
+            .select()
+            .single();
+
+        if (error) console.error(`   ❌ Failed cat: ${cat.slug}`, error.message);
+        else catMappings[cat.slug] = record.id;
+    }
+
+    // 2. Seed Topics
+    console.log("📚 Seeding Topics...");
+    const topicMappings = {};
+    const fallbackTopicByCategorySlug = {};
+    for (const top of data.topics) {
+        const categorySlug = top.cat_slug || top.category_slug;
+        const catId = catMappings[categorySlug];
+        if (!catId) continue;
+
+        const { data: record, error } = await supabase
+            .from("topics")
+            .upsert({ name: top.name, slug: top.slug, category_id: catId }, { onConflict: "slug" })
+            .select()
+            .single();
+
+        if (error) {
+            console.error(`   ❌ Failed topic: ${top.slug}`, error.message);
+        } else {
+            topicMappings[top.slug] = record.id;
+            if (categorySlug && !fallbackTopicByCategorySlug[categorySlug]) {
+                fallbackTopicByCategorySlug[categorySlug] = record.id;
+            }
+        }
+    }
+
+    // 2.5 Seed canonical Learning Cards and attach categories to them
+    console.log("🃏 Seeding canonical Learning Cards...");
+    const cardIdByKey = {};
+    const cardIds = [];
+
+    for (const cardDef of CANONICAL_LEARNING_CARDS) {
+        const cardType = CANONICAL_CARD_TYPE_BY_KEY[cardDef.key] || "core-technologies";
+        const cardPayloads = [
+            {
+                title: cardDef.title,
+                description: cardDef.description,
+                content: cardDef.description,
+                type: cardType,
+                icon: cardDef.icon,
+                color: cardDef.color,
+                order_index: cardDef.order_index,
+                is_active: true
+            },
+            {
+                title: cardDef.title,
+                description: cardDef.description,
+                content: cardDef.description,
+                type: cardType,
+                color: cardDef.color,
+                icon: cardDef.icon,
+                order_index: cardDef.order_index,
+                is_active: true
+            }
+        ];
+
+        const { data: cardRecord, error: cardError } = await insertFirstValidPayload("learning_cards", cardPayloads);
+
+        if (cardError || !cardRecord?.id) {
+            console.warn(`   ⚠️ Failed to seed canonical card ${cardDef.title}: ${cardError?.message || "Unknown error"}`);
+            continue;
+        }
+
+        cardIdByKey[cardDef.key] = cardRecord.id;
+        cardIds.push(cardRecord.id);
+    }
+
+    const categoryCardKeyBySlug = {};
+    for (const category of data.categories) {
+        const categoryId = catMappings[category.slug];
+        if (!categoryId) continue;
+
+        const cardKey = mapCategoryToCanonicalCardKey(category);
+        const cardId = cardIdByKey[cardKey] || null;
+        categoryCardKeyBySlug[category.slug] = cardKey;
+
+        if (!cardId) continue;
+
+        const { error: categoryLinkError } = await supabase
+            .from("categories")
+            .update({ learning_card_id: cardId })
+            .eq("id", categoryId);
+
+        if (categoryLinkError) {
+            console.warn(`   ⚠️ Failed to attach category ${category.slug} to ${cardKey}: ${categoryLinkError.message}`);
+        }
+    }
+
+    // 3. Seed Questions
+    console.log("❓ Seeding Questions...");
+    const normalizedQuestions = data.questions.map(normalizeQuestion);
+    const failedQuestions = [];
+    let successCount = 0;
+    const questionIdsByCardId = {};
+    const unassignedQuestionIds = [];
+
+    if (cardIds.length === 0) {
+        throw new Error("No canonical learning cards were created. Aborting question/plan seeding.");
+    }
+
+    for (let index = 0; index < normalizedQuestions.length; index++) {
+        const question = normalizedQuestions[index];
+        const catId = catMappings[question.cat_slug];
+        const topicId = topicMappings[question.topic_slug] || fallbackTopicByCategorySlug[question.cat_slug] || null;
+
+        if (!question.title || !question.content) {
+            const reason = "Missing required title/content after normalization";
+            console.error(`   ❌ Question ${index + 1}/${normalizedQuestions.length} failed: ${reason}`);
+            failedQuestions.push({
+                index: index + 1,
+                reason,
+                question
+            });
+            continue;
+        }
+
+        if (!catId) {
+            const reason = `Category slug could not be resolved (cat_slug=${question.cat_slug}, topic_slug=${question.topic_slug})`;
+            console.error(`   ❌ Question ${index + 1}/${normalizedQuestions.length} failed: ${reason}`);
+            failedQuestions.push({
+                index: index + 1,
+                reason,
+                question
+            });
+            continue;
+        }
+
+        const payload = {
+            title: question.title,
+            content: question.content,
+            type: question.type,
+            difficulty: question.difficulty,
+            points: question.points,
+            options: question.options,
+            correct_answer: question.correct_answer,
+            explanation: question.explanation,
+            category_id: catId,
+            topic_id: topicId,
+            learning_card_id: cardIdByKey[categoryCardKeyBySlug[question.cat_slug]] || null,
+            tags: question.tags,
+            metadata: question.metadata,
+            resources: question.resources,
+            is_active: true
+        };
+
+        const { data: insertedQuestion, error } = await supabase
+            .from("questions")
+            .insert(payload)
+            .select("id, learning_card_id")
+            .single();
+
+        if (error) {
+            console.error(`   ❌ Question ${index + 1}/${normalizedQuestions.length} failed: ${error.message}`);
+            failedQuestions.push({
+                index: index + 1,
+                reason: error.message,
+                question,
+                payload
+            });
+            continue;
+        }
+
+        const assignedCardId = insertedQuestion?.learning_card_id || payload.learning_card_id;
+        if (insertedQuestion?.id) {
+            if (assignedCardId) {
+                if (!questionIdsByCardId[assignedCardId]) {
+                    questionIdsByCardId[assignedCardId] = [];
+                }
+                questionIdsByCardId[assignedCardId].push(insertedQuestion.id);
+            } else {
+                unassignedQuestionIds.push(insertedQuestion.id);
+            }
+        }
+
+        successCount += 1;
+        console.log(`   ✅ Question ${index + 1}/${normalizedQuestions.length} seeded: ${question.external_ref || question.title}`);
+    }
+
+    writeFailedQuestionLog(failedQuestions);
+    console.log(`   ✅ Questions seeded: ${successCount}`);
+    if (failedQuestions.length) {
+        console.log(`   ⚠️ Questions failed: ${failedQuestions.length}`);
+    }
+
+    // 4. Seed Learning Plans with Spaced Repetition Architecture
+    // Plans: 1) Initial 2) Review 3) Advanced 4) Maintenance
+    console.log("🧭 Seeding Learning Plans (Spaced Repetition)...");
+    
+    // Collect all questions by card to understand question distribution
+    const allCardQuestionsMap = {};
+    for (const cardId of cardIds) {
+        allCardQuestionsMap[cardId] = questionIdsByCardId[cardId] || [];
+    }
+
+    // Generate 4 plans per topic
+    const planSequences = [1, 2, 3, 4];
+    const plansCreated = [];
+
+    for (const planSeq of planSequences) {
+        const metadata = generatePlanMetadata(planSeq);
+        const displayLabel = getDisplayLabel(metadata.new_question_count, metadata.review_question_count);
+
+        const planPayloads = [
+            {
+                title: metadata.title,
+                description: metadata.description,
+                estimated_duration: planSeq * 5, // 5, 10, 15, 20 minutes per sequence
+                estimated_hours: Math.ceil(planSeq * 5 / 60),
+                plan_type: metadata.plan_type,
+                sequence_index: metadata.sequence_index,
+                new_question_count: metadata.new_question_count,
+                review_question_count: metadata.review_question_count,
+                display_label: displayLabel,
+                status: "published",
+                is_public: true,
+                is_active: true
+            },
+            {
+                name: metadata.title,
+                description: metadata.description,
+                estimated_duration: planSeq * 5,
+                plan_type: metadata.plan_type,
+                sequence_index: metadata.sequence_index,
+                display_label: displayLabel,
+                status: "published",
+                is_public: true,
+                is_active: true
+            },
+            {
+                title: metadata.title,
+                description: metadata.description,
+                display_label: displayLabel,
+                is_public: true,
+                is_active: true
+            }
+        ];
+
+        const { data: planRecord, error: planError } = await insertFirstValidPayload("learning_plans", planPayloads);
+
+        if (planError || !planRecord?.id) {
+            console.warn(`   ⚠️ Failed to seed plan (${metadata.title}): ${planError?.message || "Unknown error"}`);
+            continue;
+        }
+
+        plansCreated.push({ id: planRecord.id, sequence: planSeq, metadata });
+        console.log(`   ✅ Plan ${planSeq}: ${metadata.title}`);
+
+        // Include all cards in the plan
+        const planCardRows = cardIds.map((cardId, index) => ({
+            plan_id: planRecord.id,
+            card_id: cardId,
+            order_index: index,
+            is_active: true
+        }));
+
+        if (planCardRows.length) {
+            const { error: planCardsError } = await supabase
+                .from("plan_cards")
+                .insert(planCardRows);
+
+            if (planCardsError) {
+                console.warn(`   ⚠️ Failed linking cards to plan ${planSeq}: ${planCardsError.message}`);
+            }
+        }
+
+        // Distribute questions according to plan type
+        const planQuestionRows = [];
+        let questionIndex = 0;
+
+        for (const cardId of cardIds) {
+            const cardQuestionIds = questionIdsByCardId[cardId] || [];
+            if (cardQuestionIds.length === 0) continue;
+
+            // Group questions hypothetically by difficulty
+            const grouped = groupQuestionsByDifficulty(cardQuestionIds);
+
+            switch (planSeq) {
+                case 1: {
+                    // Plan 1 (Foundations): ~10 new questions spread across cards
+                    const newPerCard = Math.max(1, Math.floor(metadata.new_question_count / cardIds.length));
+                    for (let i = 0; i < Math.min(newPerCard, cardQuestionIds.length); i++) {
+                        planQuestionRows.push({
+                            plan_id: planRecord.id,
+                            question_id: cardQuestionIds[i],
+                            order_index: planQuestionRows.length,
+                            is_review: false,
+                            parent_plan_id: null,
+                            difficulty_tier: i < grouped.easy.length ? "easy" : i < grouped.easy.length + grouped.medium.length ? "medium" : "hard",
+                            is_active: true
+                        });
+                    }
+                    break;
+                }
+                case 2: {
+                    // Plan 2 (Review & Deepen): 50% new + 50% review from Plan 1
+                    const newPerCard = Math.max(1, Math.floor(metadata.new_question_count / cardIds.length));
+                    const reviewPerCard = Math.max(1, Math.floor(metadata.review_question_count / cardIds.length));
+
+                    // Add new questions (continuing from where Plan 1 left off)
+                    const startNew = Math.ceil(metadata.new_question_count / cardIds.length);
+                    for (let i = startNew; i < Math.min(startNew + newPerCard, cardQuestionIds.length); i++) {
+                        planQuestionRows.push({
+                            plan_id: planRecord.id,
+                            question_id: cardQuestionIds[i],
+                            order_index: planQuestionRows.length,
+                            is_review: false,
+                            parent_plan_id: null,
+                            difficulty_tier: "medium",
+                            is_active: true
+                        });
+                    }
+
+                    // Add review questions from Plan 1 (hardest ones)
+                    const reviewQs = grouped.hard.length > 0 ? grouped.hard : grouped.medium;
+                    for (let i = 0; i < Math.min(reviewPerCard, reviewQs.length); i++) {
+                        planQuestionRows.push({
+                            plan_id: planRecord.id,
+                            question_id: reviewQs[i],
+                            order_index: planQuestionRows.length,
+                            is_review: true,
+                            parent_plan_id: plansCreated[0].id, // Reference Plan 1
+                            difficulty_tier: "hard",
+                            is_active: true
+                        });
+                    }
+                    break;
+                }
+                case 3: {
+                    // Plan 3 (Advanced Mastery): 33% new + 67% review from Plans 1-2
+                    const newPerCard = Math.max(1, Math.floor(metadata.new_question_count / cardIds.length));
+                    const reviewPerCard = Math.max(2, Math.floor(metadata.review_question_count / cardIds.length));
+
+                    // Add advanced new questions
+                    const startAdv = Math.ceil((metadata.new_question_count + metadata.review_question_count) / cardIds.length) + 2;
+                    for (let i = startAdv; i < Math.min(startAdv + newPerCard, cardQuestionIds.length); i++) {
+                        planQuestionRows.push({
+                            plan_id: planRecord.id,
+                            question_id: cardQuestionIds[i],
+                            order_index: planQuestionRows.length,
+                            is_review: false,
+                            parent_plan_id: null,
+                            difficulty_tier: "hard",
+                            is_active: true
+                        });
+                    }
+
+                    // Add review questions (hardest from Plans 1 and 2)
+                    const allReviewQs = [...grouped.hard, ...grouped.medium].slice(0, reviewPerCard);
+                    for (const qId of allReviewQs) {
+                        planQuestionRows.push({
+                            plan_id: planRecord.id,
+                            question_id: qId,
+                            order_index: planQuestionRows.length,
+                            is_review: true,
+                            parent_plan_id: plansCreated[Math.random() > 0.5 ? 0 : 1]?.id || null, // Random from Plan 1-2
+                            difficulty_tier: "hard",
+                            is_active: true
+                        });
+                    }
+                    break;
+                }
+                case 4: {
+                    // Plan 4 (Weekly Check-in): ~20% new + 80% review from all previous plans
+                    const newPerCard = Math.max(1, Math.floor(metadata.new_question_count / cardIds.length));
+                    const reviewPerCard = Math.max(2, Math.floor(metadata.review_question_count / cardIds.length));
+
+                    // Add final new questions
+                    for (let i = cardQuestionIds.length - newPerCard; i < cardQuestionIds.length; i++) {
+                        if (i >= 0) {
+                            planQuestionRows.push({
+                                plan_id: planRecord.id,
+                                question_id: cardQuestionIds[i],
+                                order_index: planQuestionRows.length,
+                                is_review: false,
+                                parent_plan_id: null,
+                                difficulty_tier: "hard",
+                                is_active: true
+                            });
+                        }
+                    }
+
+                    // Add maintenance review (mixed difficulty from all previous)
+                    const mixedReviewQs = [...grouped.easy.slice(0, 2), ...grouped.medium.slice(0, 3), ...grouped.hard.slice(0, 3)].slice(0, reviewPerCard);
+                    for (const qId of mixedReviewQs) {
+                        planQuestionRows.push({
+                            plan_id: planRecord.id,
+                            question_id: qId,
+                            order_index: planQuestionRows.length,
+                            is_review: true,
+                            parent_plan_id: plansCreated[Math.floor(Math.random() * (plansCreated.length - 1))]?.id || null,
+                            difficulty_tier: "medium",
+                            is_active: true
+                        });
+                    }
+                    break;
+                }
+            }
+        }
+
+        // Also add unassigned questions to maintenance plan
+        if (planSeq === 4) {
+            for (let i = 0; i < Math.min(3, unassignedQuestionIds.length); i++) {
+                planQuestionRows.push({
+                    plan_id: planRecord.id,
+                    question_id: unassignedQuestionIds[i],
+                    order_index: planQuestionRows.length,
+                    is_review: false,
+                    parent_plan_id: null,
+                    difficulty_tier: "medium",
+                    is_active: true
+                });
+            }
+        }
+
+        // Insert plan questions
+        if (planQuestionRows.length) {
+            for (const row of planQuestionRows) {
+                const { error: planQuestionError } = await insertFirstValidPayload("plan_questions", [
+                    row,
+                    {
+                        plan_id: row.plan_id,
+                        question_id: row.question_id,
+                        order_index: row.order_index,
+                        is_review: row.is_review
+                    },
+                    {
+                        plan_id: row.plan_id,
+                        question_id: row.question_id
+                    }
+                ]);
+
+                if (planQuestionError) {
+                    console.warn(`   ⚠️ Failed linking question to plan ${planSeq}: ${planQuestionError.message}`);
+                }
+            }
+        }
+
+        console.log(`   ✅ Linked ${planQuestionRows.length} questions to ${metadata.title}`);
+    }
+
+    console.log("✨ Seeding completed!");
+}
+
+seed();

--- a/tools/seed/starter-data.template.json
+++ b/tools/seed/starter-data.template.json
@@ -1,0 +1,57 @@
+{
+  "categories": [
+    {
+      "name": "JavaScript",
+      "slug": "javascript",
+      "description": "Core language concepts",
+      "card_type": "concept",
+      "icon": "code",
+      "color": "#f7df1e",
+      "order_index": 1
+    }
+  ],
+  "topics": [
+    {
+      "name": "Closures",
+      "slug": "closures",
+      "cat_slug": "javascript"
+    }
+  ],
+  "questions": [
+    {
+      "title": "What is a closure?",
+      "content": "Explain closure with one practical example.",
+      "type": "multiple-choice",
+      "difficulty": "beginner",
+      "points": 1,
+      "options": [
+        {
+          "id": "A",
+          "text": "A function with lexical scope access",
+          "isCorrect": true
+        },
+        {
+          "id": "B",
+          "text": "A CSS layout pattern",
+          "isCorrect": false
+        }
+      ],
+      "correct_answer": "A",
+      "explanation": "Closures keep references to outer-scope variables.",
+      "cat_slug": "javascript",
+      "topic_slug": "closures",
+      "tags": ["javascript", "guided", "free-style", "custom"],
+      "metadata": {
+        "learning_modes": ["guided", "free-style", "custom"],
+        "source": "NotebookLM"
+      },
+      "resources": [
+        {
+          "type": "article",
+          "title": "MDN Closures",
+          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Closures"
+        }
+      ]
+    }
+  ]
+}

--- a/tools/verify-system.mjs
+++ b/tools/verify-system.mjs
@@ -1,0 +1,36 @@
+import { createClient } from "@supabase/supabase-js";
+import * as dotenv from "dotenv";
+
+dotenv.config({ path: ".env.local" });
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+async function verify() {
+    console.log("🔍 Running System Smoke Test...");
+
+    // 1. Check Env
+    if (!supabaseUrl || !supabaseKey) {
+        console.error("   ❌ Environment variables missing.");
+        process.exit(1);
+    }
+    console.log("   ✅ Environment variables present.");
+
+    // 2. Check Supabase Connectivity
+    const supabase = createClient(supabaseUrl, supabaseKey);
+    const { data: cat, error: catError } = await supabase.from("categories").select("count");
+
+    if (catError) {
+        console.error("   ❌ Supabase connection failed:", catError.message);
+        process.exit(1);
+    }
+    console.log("   ✅ Supabase connection successful.");
+
+    // 3. Check Data Presence
+    const { count: qCount } = await supabase.from("questions").select("*", { count: 'exact', head: true });
+    console.log(`   📊 Questions in DB: ${qCount || 0}`);
+
+    console.log("\n🚀 System is HEALTHY.");
+}
+
+verify();


### PR DESCRIPTION
## Summary\n- fix seeding/runtime relation behavior so hierarchy displays as LearningPlan -> Cards -> Categories -> Topics -> Questions\n- preserve existing category to card linkage before fallback mapping in content management hook\n- wire content-management action buttons (create/edit/delete for categories/topics, create/edit card routing) to real handlers\n- render topic-level questions in both Learning Cards and Plans hierarchy views\n\n## Validation\n- npm run type-check\n- npm run seed\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin content management: full create/edit/delete for categories and topics.
  * Learning Cards: expandable topic view now shows per-question cards.
  * Plans UI: shows question lists per topic with badges indicating “In Plan” vs “Available”.
  * Large set of new seeded educational content (JavaScript, web performance, rendering patterns, SWR, etc.).

* **Documentation**
  * Added seeding README describing workflow and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->