### PR TITLE
fix(security-scan): restore Gitleaks Code Scanning uploads

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -27,14 +27,45 @@ jobs:
           wget "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
           tar -xzf gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz
           chmod +x gitleaks
-          ./gitleaks detect --config .gitleaks.toml --verbose --report-format sarif --report-path gitleaks-results.sarif || true
+
+          # Use repository config when present, otherwise run with gitleaks defaults.
+          if [ -f .gitleaks.toml ]; then
+            echo "Using .gitleaks.toml configuration"
+            ./gitleaks detect --source . --config .gitleaks.toml --verbose --report-format sarif --report-path gitleaks-results.sarif || true
+          else
+            echo "No .gitleaks.toml found; running with default rules"
+            ./gitleaks detect --source . --verbose --report-format sarif --report-path gitleaks-results.sarif || true
+          fi
+
+          # Ensure SARIF exists so GitHub code scanning can always process this tool.
+          if [ ! -f gitleaks-results.sarif ]; then
+            echo "Gitleaks did not produce SARIF output; writing empty SARIF report"
+            cat > gitleaks-results.sarif <<'EOF'
+          {
+            "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+            "version": "2.1.0",
+            "runs": [
+              {
+                "tool": {
+                  "driver": {
+                    "name": "Gitleaks",
+                    "informationUri": "https://github.com/gitleaks/gitleaks",
+                    "rules": []
+                  }
+                },
+                "results": []
+              }
+            ]
+          }
+          EOF
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Gitleaks results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
         continue-on-error: true
-        if: always() && hashFiles('gitleaks-results.sarif') != ''
+        if: always()
         with:
           sarif_file: "gitleaks-results.sarif"
 


### PR DESCRIPTION
## Summary\n- fix Gitleaks step in security-scan workflow when .gitleaks.toml is missing\n- add fallback scan mode using default gitleaks rules\n- always generate a valid SARIF file, even when scanner fails to emit one\n- always run SARIF upload step for Gitleaks\n\n## Why\nGitHub Security showed Gitleaks tool status stale with setup error because the workflow expected .gitleaks.toml, failed early, and never uploaded SARIF.\n\n## Validation\n- workflow YAML parsed successfully\n- commit pushed: 33b3ea74\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security scanning workflow to handle configuration variations and ensure consistent reporting across different setup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->