### PR TITLE
fix(security-scan): prevent Trivy code-scanning alert explosion

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -74,6 +74,8 @@ jobs:
         with:
           scan-type: "fs"
           scan-ref: "."
+          scanners: "vuln,misconfig"
+          skip-files: "gitleaks-results.sarif,trivy-results.sarif,**/*.sarif"
           format: "sarif"
           output: "trivy-results.sarif"
 


### PR DESCRIPTION
## Summary
- disable Trivy secret scanner in CI (Gitleaks remains the single secret-scanning source)
- exclude generated SARIF files from Trivy filesystem scan (, , )

## Why
Trivy was scanning generated SARIF artifacts and re-detecting masked secret payloads inside reports, creating large volumes of false-positive code-scanning alerts.

## Expected impact
- no new Trivy alerts from generated SARIF artifacts
- security/code-scanning signal returns to actionable findings only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved security scanning configuration to better detect vulnerabilities and misconfigurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->