### PR TITLE
fix(admin): restore main pipelines by removing invalid question conversion

### DIFF
--- a/apps/admin/src/app/admin/content-management/page.tsx
+++ b/apps/admin/src/app/admin/content-management/page.tsx
@@ -24,61 +24,9 @@ import {
   QuestionFormModal,
   CardFormModal,
 } from "@elzatona/common-ui";
-import type { AdminQuestion, AdminUnifiedQuestion } from "@elzatona/types";
+import type { AdminUnifiedQuestion } from "@elzatona/types";
 import { Loader2 } from "lucide-react";
 import { useContentManagement } from "./hooks/useContentManagement";
-
-function toUnifiedQuestions(
-  questions: AdminQuestion[],
-): AdminUnifiedQuestion[] {
-  return questions.map((question) => {
-    const difficulty =
-      question.difficulty === "beginner" ||
-      question.difficulty === "intermediate" ||
-      question.difficulty === "advanced"
-        ? question.difficulty
-        : "intermediate";
-
-    const type =
-      question.type === "multiple-choice" ||
-      question.type === "true-false" ||
-      question.type === "code" ||
-      question.type === "mcq"
-        ? question.type
-        : "multiple-choice";
-
-    const rawOptions = Array.isArray(question.options) ? question.options : [];
-    const options = rawOptions
-      .filter((option): option is string => typeof option === "string")
-      .map((option, index) => ({
-        id: `opt-${index + 1}`,
-        text: option,
-        isCorrect: option === question.correct_answer,
-      }));
-
-    return {
-      id: question.id,
-      title: question.title,
-      content: question.content,
-      difficulty,
-      type,
-      options,
-      category_id: question.category_id,
-      topic_id: question.topic_id,
-      learning_card_id: question.learning_card_id,
-      correct_answer: question.correct_answer,
-      explanation: question.explanation,
-      hints: question.hints,
-      tags: question.tags,
-      isActive: Boolean(question.is_active),
-      createdAt: question.created_at,
-      updatedAt: question.updated_at,
-      is_active: question.is_active,
-      created_at: question.created_at,
-      updated_at: question.updated_at,
-    };
-  });
-}
 
 export default function ContentManagementPage() {
   const router = useRouter();
@@ -183,7 +131,7 @@ export default function ContentManagementPage() {
     submitCard,
   } = useContentManagement();
 
-  const unifiedQuestions = toUnifiedQuestions(questions);
+  const unifiedQuestions: AdminUnifiedQuestion[] = questions;
 
   if (loading) {
     return (


### PR DESCRIPTION
## Summary\n- fix TypeScript failure in admin content management page on main\n- remove redundant  conversion\n- use  from hook directly (already )\n\n## Why\nMain branch pipelines fail in multiple workflows at the same line:\n- \n- \n\nThis single type-check error breaks:\n- CI Checks (type-check/build)\n- Admin Tests (build job)\n- E2E Tests (all shards fail at build stage before tests)\n\n## Validation\n- 
> zatona-web@1.0.0 type-check:ci
> bash scripts/ci-quality-gate.sh typecheck


> zatona-web@1.0.0 type-check
> npx tsc --noEmit passes\n- ▲ Next.js 16.2.1 (Turbopack)
- Environments: .env.local
- Experiments (use with caution):
  ✓ forceSwcTransforms

  Creating an optimized production build ...
✓ Compiled successfully in 6.2s
  Running TypeScript ...
  Finished TypeScript in 4.8s ...
  Collecting page data using 7 workers ...
[Questions API] Environment: PRODUCTION
[Questions API] Project: unknown
[Questions API] Supabase: ...
[Questions API] Debug Logging: OFF
[Questions API] Test Data: DISABLED
[Questions API] Environment: PRODUCTION
[Questions API] Project: unknown
[Questions API] Supabase: ...
[Questions API] Debug Logging: OFF
[Questions API] Test Data: DISABLED
  Generating static pages using 7 workers (0/26) ...
  Generating static pages using 7 workers (6/26) 
  Generating static pages using 7 workers (12/26) 
[Questions API] Environment: PRODUCTION
[Questions API] Project: unknown
[Questions API] Supabase: ...
[Questions API] Debug Logging: OFF
[Questions API] Test Data: DISABLED
  Generating static pages using 7 workers (19/26) 
✓ Generating static pages using 7 workers (26/26) in 390ms
  Finalizing page optimization ...

Route (app)
┌ ○ /
├ ○ /_not-found
├ ○ /admin
├ ○ /admin/content-management
├ ○ /admin/content/questions
├ ○ /admin/dashboard
├ ○ /admin/frontend-tasks
├ ○ /admin/learning-cards
├ ○ /admin/login
├ ○ /admin/logs
├ ○ /admin/problem-solving
├ ○ /admin/questions
├ ○ /admin/users
├ ○ /api-docs
├ ƒ /api/admin/auth
├ ƒ /api/admin/dashboard-stats
├ ƒ /api/admin/frontend-tasks
├ ƒ /api/admin/frontend-tasks/[id]
├ ƒ /api/admin/problem-solving
├ ƒ /api/admin/problem-solving/[id]
├ ƒ /api/cards
├ ƒ /api/categories
├ ƒ /api/categories/question-counts
├ ƒ /api/plans
├ ƒ /api/questions/unified
├ ƒ /api/questions/unified/[id]
├ ƒ /api/swagger
└ ƒ /api/topics


○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand passes\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed a local data conversion function from the content management page; the page now directly uses unified questions without intermediate transformation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->