### PR TITLE
fix(admin-content): restore category/topic/question counts when categories use card_type

### DIFF
--- a/apps/admin/src/app/admin/content-management/hooks/useContentManagement.ts
+++ b/apps/admin/src/app/admin/content-management/hooks/useContentManagement.ts
@@ -174,6 +174,73 @@ function buildCanonicalCards(cards: AdminLearningCard[]): {
   return { cards: canonicalCards, idsByKey };
 }
 
+function normalizeCardTypeKey(
+  cardType?: string | null,
+): CanonicalCardKey | null {
+  if (!cardType) {
+    return null;
+  }
+
+  const normalized = cardType.trim().toLowerCase();
+
+  if (
+    normalized === "core" ||
+    normalized === "core technologies" ||
+    normalized === "core_technologies" ||
+    normalized === "core-technologies"
+  ) {
+    return "core";
+  }
+
+  if (
+    normalized === "framework" ||
+    normalized === "framework questions" ||
+    normalized === "framework_questions" ||
+    normalized === "framework-questions"
+  ) {
+    return "framework";
+  }
+
+  if (
+    normalized === "problem" ||
+    normalized === "problem solving" ||
+    normalized === "problem_solving" ||
+    normalized === "problem-solving"
+  ) {
+    return "problem";
+  }
+
+  if (
+    normalized === "system" ||
+    normalized === "system design" ||
+    normalized === "system_design" ||
+    normalized === "system-design"
+  ) {
+    return "system";
+  }
+
+  return null;
+}
+
+function mapCategoryToCard(
+  category: DatabaseCategoryRecord,
+  idsByKey: Record<CanonicalCardKey, string>,
+): AdminCategory | null {
+  if (category.learning_card_id) {
+    return category as AdminCategory;
+  }
+
+  const key = normalizeCardTypeKey(category.card_type);
+  if (!key) {
+    return null;
+  }
+
+  return {
+    ...(category as AdminCategory),
+    learning_card_id: idsByKey[key],
+  };
+}
+
 function transformQuestion(q: any): AdminUnifiedQuestion {
   return {
     ...q,
@@ -755,15 +822,14 @@ export function useContentManagement() {
       ].filter((message): message is string => Boolean(message));
 
       const normalizedCards = cardsResult.data;
-      buildCanonicalCards(normalizedCards);
+      const { cards: canonicalCards, idsByKey } =
+        buildCanonicalCards(normalizedCards);
 
-      // Strict DB-relation filtering: only display categories with valid learning_card_id FK
-      // This ensures the hierarchy is accurate to the database state (no inference fallback)
-      const mappedCategories = categoriesResult.data.filter(
-        (category) => (category as AdminCategory).learning_card_id != null,
-      );
+      const mappedCategories = categoriesResult.data
+        .map((category) => mapCategoryToCard(category, idsByKey))
+        .filter((category): category is AdminCategory => category !== null);
 
-      setCards(normalizedCards);
+      setCards(canonicalCards);
       setPlans(plansResult.data);
       setQuestions(questionsResult.data.map(transformQuestion));
       setCategories(mappedCategories);


### PR DESCRIPTION
## Summary
- Restore category visibility and card hierarchy counts in admin content management when category rows are linked by card_type instead of learning_card_id.
- Keep canonical learning-card rendering consistent across environments.

## Root Cause
- The hook only kept categories with non-null learning_card_id.
- In deployed data, some categories are linked via card_type, so they were filtered out.
- Once categories were dropped, per-card category/topic/question badges displayed zero even though topics/questions existed.

## Fix
- Add robust card_type normalization (core, framework, problem, system variants).
- Map categories missing learning_card_id onto canonical card IDs derived from loaded cards.
- Keep only categories that can be reliably mapped.

## Impact
- Category counts are restored in production UI.
- Topic/question badge counts under each card compute correctly again.
- No API contract changes; only safer client-side normalization.

## Validation
- npm run type-check passes.
