### PR TITLE
fix(database): use server Supabase credentials first in API repository factory

### DIFF
--- a/libs/database/src/repositories/RepositoryFactory.ts
+++ b/libs/database/src/repositories/RepositoryFactory.ts
@@ -293,14 +293,14 @@ export function createRepositoryFactoryFromEnv(): RepositoryFactory {
     | "mongodb"
     | "mysql";
 
-  // Support both public and server-only Supabase env vars.
-  // Public vars are needed for browser usage; server routes may only have server vars.
+  // Prefer server-only Supabase env vars in API/runtime contexts.
+  // Fall back to public vars for local/dev compatibility.
   const resolvedSupabaseUrl =
-    process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL || "";
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL || "";
   const resolvedSupabaseKey =
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
-    process.env.SUPABASE_ANON_KEY ||
     process.env.SUPABASE_SERVICE_ROLE_KEY ||
+    process.env.SUPABASE_ANON_KEY ||
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
     "";
 
   const config: RepositoryFactoryConfig = {


### PR DESCRIPTION
- prefer SUPABASE_URL over NEXT_PUBLIC_SUPABASE_URL
- prefer SUPABASE_SERVICE_ROLE_KEY over anon keys
- keep fallback to public vars for local compatibility
- explains this prevents deployed API data mismatch due anon/RLS differences

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment variable resolution order for database configuration to support multiple setup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->