### PR TITLE
ci(cicd): enforce strict CI before CD deployment gate

### DIFF
--- a/.github/workflows/admin-tests.yml
+++ b/.github/workflows/admin-tests.yml
@@ -3,18 +3,8 @@ name: Admin Tests
 on:
   push:
     branches: [main, develop, "release/**"]
-    paths:
-      - "apps/admin/**"
-      - "libs/database/**"
-      - "libs/contexts/**"
-      - "libs/common-ui/**"
   pull_request:
     branches: [main, develop, "release/**"]
-    paths:
-      - "apps/admin/**"
-      - "libs/database/**"
-      - "libs/contexts/**"
-      - "libs/common-ui/**"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -57,7 +57,7 @@ jobs:
           # Run Vitest tests for admin app (AdminLoginPage)
           echo "📦 Testing AdminLoginPage in apps/admin..."
           NODE_OPTIONS=--max-old-space-size=768 npx vitest run apps/admin/src/app/admin/login/page.test.tsx
-        continue-on-error: true
+        continue-on-error: false
         env:
           NODE_OPTIONS: "--max-old-space-size=768"
           CI: "true"

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -1,0 +1,146 @@
+name: Deploy Main (CI -> CD)
+
+on:
+  workflow_run:
+    workflows:
+      - CI Checks (Lint, Type Check, Build)
+      - Admin Tests
+      - E2E Tests
+      - Security Scan
+      - CodeQL Analysis
+      - SonarCloud Code Analysis
+    types: [completed]
+
+concurrency:
+  group: deploy-main-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  gate-ci:
+    name: Validate Required CI Workflows
+    if: github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      can_deploy: ${{ steps.wait-for-ci.outputs.can_deploy }}
+    steps:
+      - name: Wait for all required workflows on this commit
+        id: wait-for-ci
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const headSha = context.payload.workflow_run.head_sha;
+
+            const requiredWorkflows = [
+              'CI Checks (Lint, Type Check, Build)',
+              'Admin Tests',
+              'E2E Tests',
+              'Security Scan',
+              'CodeQL Analysis',
+              'SonarCloud Code Analysis',
+            ];
+
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+            const timeoutMs = 45 * 60 * 1000;
+            const pollEveryMs = 30 * 1000;
+            const startedAt = Date.now();
+
+            while (Date.now() - startedAt < timeoutMs) {
+              const runsResponse = await github.rest.actions.listWorkflowRunsForRepo({
+                owner,
+                repo,
+                head_sha: headSha,
+                per_page: 100,
+              });
+
+              const runByName = new Map();
+              for (const run of runsResponse.data.workflow_runs) {
+                if (!requiredWorkflows.includes(run.name)) {
+                  continue;
+                }
+                const previous = runByName.get(run.name);
+                if (!previous || previous.run_number < run.run_number) {
+                  runByName.set(run.name, run);
+                }
+              }
+
+              const missing = requiredWorkflows.filter((name) => !runByName.has(name));
+              const pending = [];
+              const failed = [];
+
+              for (const name of requiredWorkflows) {
+                const run = runByName.get(name);
+                if (!run) {
+                  continue;
+                }
+
+                if (run.status !== 'completed') {
+                  pending.push(`${name} (status=${run.status})`);
+                  continue;
+                }
+
+                if (run.conclusion !== 'success') {
+                  failed.push(`${name} (conclusion=${run.conclusion})`);
+                }
+              }
+
+              core.info(`Checked workflows for ${headSha}`);
+              core.info(`Missing: ${missing.join(', ') || 'none'}`);
+              core.info(`Pending: ${pending.join(', ') || 'none'}`);
+              core.info(`Failed: ${failed.join(', ') || 'none'}`);
+
+              if (missing.length === 0 && pending.length === 0) {
+                if (failed.length > 0) {
+                  core.setFailed(`CI gate failed. Non-success workflows: ${failed.join('; ')}`);
+                  core.setOutput('can_deploy', 'false');
+                  return;
+                }
+
+                core.setOutput('can_deploy', 'true');
+                return;
+              }
+
+              await sleep(pollEveryMs);
+            }
+
+            core.setFailed('Timed out waiting for all required CI workflows to complete on this commit.');
+            core.setOutput('can_deploy', 'false');
+
+  deploy:
+    name: Deploy Website Then Admin
+    needs: gate-ci
+    if: needs.gate-ci.outputs.can_deploy == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    environment:
+      name: production
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install --no-audit
+
+      - name: Validate deployment secrets
+        run: |
+          if [ -z "${{ secrets.VERCEL_TOKEN }}" ]; then
+            echo "Missing VERCEL_TOKEN secret"
+            exit 1
+          fi
+
+      - name: Deploy website
+        run: npx vercel deploy --prod --yes --cwd apps/website --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy admin
+        run: npx vercel deploy --prod --yes --cwd apps/admin --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -364,7 +364,7 @@ jobs:
         if: always() && env.RUN_E2E_TESTS == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
+          name: playwright-report-shard-${{ matrix.shardIndex }}
           path: apps/website/playwright-report/
           retention-days: 7
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -255,7 +255,6 @@ jobs:
             --workers=1 \
             --reporter=html,list \
             --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
-        continue-on-error: true
         env:
           APP_ENV: test
           NODE_ENV: test
@@ -279,7 +278,6 @@ jobs:
             --workers=1 \
             --reporter=html,list \
             --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
-        continue-on-error: true
         env:
           APP_ENV: test
           NODE_ENV: test
@@ -303,7 +301,6 @@ jobs:
             --workers=1 \
             --reporter=html,list \
             --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
-        continue-on-error: true
         env:
           APP_ENV: test
           NODE_ENV: test
@@ -325,7 +322,6 @@ jobs:
             --workers=1 \
             --reporter=html,list \
             --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
-        continue-on-error: true
         env:
           APP_ENV: test
           NODE_ENV: test
@@ -349,7 +345,6 @@ jobs:
             --workers=1 \
             --reporter=html,list \
             --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
-        continue-on-error: true
         env:
           APP_ENV: test
           NODE_ENV: test

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,84 @@
+name: SonarCloud Code Analysis
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main, develop]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sonarqube:
+    name: SonarQube
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install --no-audit
+
+      - name: Validate Sonar token is configured
+        run: |
+          if [ -z "${{ secrets.SONAR_TOKEN }}" ]; then
+            echo "SONAR_TOKEN secret is required for SonarCloud analysis"
+            exit 1
+          fi
+
+      - name: Run lint check
+        run: npm run lint:ci
+        env:
+          NODE_OPTIONS: "--max-old-space-size=1536"
+
+      - name: TypeScript type checking
+        run: npm run type-check:ci
+        env:
+          NODE_OPTIONS: "--max-old-space-size=1536"
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.TEST_SUPABASE_URL || 'https://placeholder.supabase.co' }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.TEST_SUPABASE_ANON_KEY || 'placeholder-key' }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET || 'placeholder-secret' }}
+
+      - name: Run unit tests with coverage
+        run: |
+          npm run test:unit -- --coverage --coverageReporters=lcov --coverageDirectory=coverage
+        env:
+          NODE_ENV: test
+          APP_ENV: test
+          CI: "true"
+          NODE_OPTIONS: "--max-old-space-size=1536"
+          JEST_MAX_WORKERS: "1"
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.TEST_SUPABASE_URL || 'https://placeholder.supabase.co' }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.TEST_SUPABASE_ANON_KEY || 'placeholder-key' }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.TEST_SUPABASE_SERVICE_ROLE_KEY || 'placeholder-service-role-key' }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET || 'placeholder-secret' }}
+
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v6
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_SCANNER_OPTS: "-Xmx2048m"
+        with:
+          projectBaseDir: .
+
+      - name: Upload coverage reports
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage/lcov.info
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: false
+        continue-on-error: true

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -52,20 +52,6 @@ jobs:
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.TEST_SUPABASE_ANON_KEY || 'placeholder-key' }}
           JWT_SECRET: ${{ secrets.JWT_SECRET || 'placeholder-secret' }}
 
-      - name: Run unit tests with coverage
-        run: |
-          npm run test:unit -- --coverage --coverageReporters=lcov --coverageDirectory=coverage
-        env:
-          NODE_ENV: test
-          APP_ENV: test
-          CI: "true"
-          NODE_OPTIONS: "--max-old-space-size=1536"
-          JEST_MAX_WORKERS: "1"
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.TEST_SUPABASE_URL || 'https://placeholder.supabase.co' }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.TEST_SUPABASE_ANON_KEY || 'placeholder-key' }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.TEST_SUPABASE_SERVICE_ROLE_KEY || 'placeholder-service-role-key' }}
-          JWT_SECRET: ${{ secrets.JWT_SECRET || 'placeholder-secret' }}
-
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@v6
         env:
@@ -75,6 +61,7 @@ jobs:
           projectBaseDir: .
 
       - name: Upload coverage reports
+        if: hashFiles('coverage/lcov.info') != ''
         uses: codecov/codecov-action@v4
         with:
           files: ./coverage/lcov.info

--- a/apps/admin/src/app/admin/content-management/hooks/useContentManagement.ts
+++ b/apps/admin/src/app/admin/content-management/hooks/useContentManagement.ts
@@ -24,6 +24,14 @@ type DatabaseTopicRecord = DatabaseTopic & {
 };
 
 type DatabaseCategoryRecord = AdminCategory & {
+  id: string;
+  name?: string;
+  slug?: string;
+  description?: string;
+  learning_card_id?: string;
+  is_active?: boolean;
+  created_at?: string;
+  updated_at?: string;
   card_type?: string | null;
 };
 
@@ -225,9 +233,22 @@ function normalizeCardTypeKey(
 function mapCategoryToCard(
   category: DatabaseCategoryRecord,
   idsByKey: Record<CanonicalCardKey, string>,
+  cardIdByCategoryId: Map<string, string>,
 ): AdminCategory | null {
-  if (category.learning_card_id) {
-    return category as AdminCategory;
+  const mappedCardId =
+    category.learning_card_id || cardIdByCategoryId.get(category.id);
+
+  if (mappedCardId) {
+    return {
+      id: category.id,
+      name: category.name ?? "",
+      slug: category.slug ?? toSlug(category.name ?? category.id),
+      description: category.description ?? "",
+      learning_card_id: mappedCardId,
+      is_active: category.is_active ?? true,
+      created_at: category.created_at ?? "",
+      updated_at: category.updated_at ?? "",
+    };
   }
 
   const key = normalizeCardTypeKey(category.card_type);
@@ -236,9 +257,42 @@ function mapCategoryToCard(
   }
 
   return {
-    ...(category as AdminCategory),
+    id: category.id,
+    name: category.name ?? "",
+    slug: category.slug ?? toSlug(category.name ?? category.id),
+    description: category.description ?? "",
     learning_card_id: idsByKey[key],
+    is_active: category.is_active ?? true,
+    created_at: category.created_at ?? "",
+    updated_at: category.updated_at ?? "",
   };
+}
+
+function getQuestionLearningCardId(question: AdminUnifiedQuestion): string {
+  const withLegacyCardId = question as AdminUnifiedQuestion & {
+    learningCardId?: string;
+  };
+
+  return question.learning_card_id ?? withLegacyCardId.learningCardId ?? "";
+}
+
+function buildCategoryCardLookup(
+  questions: AdminUnifiedQuestion[],
+): Map<string, string> {
+  const lookup = new Map<string, string>();
+
+  questions.forEach((question) => {
+    const categoryId = question.category_id;
+    const learningCardId = getQuestionLearningCardId(question);
+
+    if (!categoryId || !learningCardId || lookup.has(categoryId)) {
+      return;
+    }
+
+    lookup.set(categoryId, learningCardId);
+  });
+
+  return lookup;
 }
 
 function transformQuestion(q: any): AdminUnifiedQuestion {
@@ -824,9 +878,12 @@ export function useContentManagement() {
       const normalizedCards = cardsResult.data;
       const { cards: canonicalCards, idsByKey } =
         buildCanonicalCards(normalizedCards);
+      const categoryCardLookup = buildCategoryCardLookup(questionsResult.data);
 
       const mappedCategories = categoriesResult.data
-        .map((category) => mapCategoryToCard(category, idsByKey))
+        .map((category) =>
+          mapCategoryToCard(category, idsByKey, categoryCardLookup),
+        )
         .filter((category): category is AdminCategory => category !== null);
 
       setCards(canonicalCards);

--- a/apps/website/tests/e2e/global-teardown.ts
+++ b/apps/website/tests/e2e/global-teardown.ts
@@ -1,0 +1,11 @@
+/**
+ * Global teardown for Playwright E2E tests.
+ * Runs once after all test workers complete.
+ */
+
+async function globalTeardown() {
+  // Keep teardown lightweight and deterministic for CI stability.
+  console.log("🧹 Running global teardown...");
+}
+
+export default globalTeardown;

--- a/apps/website/tests/e2e/validate-test-env.ts
+++ b/apps/website/tests/e2e/validate-test-env.ts
@@ -30,8 +30,9 @@ export function validateTestEnvironment(): {
     process.env.GITHUB_ACTIONS === "true" ||
     !!process.env.TEST_SUPABASE_URL;
 
-  // Check if file exists
-  if (!existsSync(testEnvFile)) {
+  // Local development requires .env.test.local on disk.
+  // In CI, secrets are injected as environment variables, so no file is required.
+  if (!isCI && !existsSync(testEnvFile)) {
     errors.push(
       `❌ .env.test.local file is missing!\n` +
         `   Location: ${testEnvFile}\n` +


### PR DESCRIPTION
## Summary
- enforce strict CI pass requirements before deployment
- add dedicated deploy workflow that waits for all required CI/security workflows on the same commit SHA
- fail CI on test failures (remove permissive continue-on-error in key test steps)
- ensure SonarCloud workflow is active and included in the deployment gate

## Why
Deployment should only run after tests, security scans, and code quality checks are green (CI then CD).

## Required checks before deploy
- CI Checks (Lint, Type Check, Build)
- Admin Tests
- E2E Tests
- Security Scan
- CodeQL Analysis
- SonarCloud Code Analysis


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enforced stricter test-failure behavior across CI and E2E workflows.
  * Added SonarCloud code analysis and a gated, automated production deployment pipeline with concurrency control.
  * Removed path filters so workflows trigger on main/develop/release branches; CI no longer requires a local test env file in CI environments.
  * Added a global E2E teardown hook.

* **Bug Fixes**
  * Fixed content-management mapping so categories consistently normalize and resolve associated learning-card assignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->