### PR TITLE
fix(ci): run Deploy Main only after push CI on main

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   gate-ci:
     name: Validate Required CI Workflows
-    if: github.event.workflow_run.head_branch == 'main'
+    if: github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Why
Deploy Main runs were showing as skipped without website/admin deploy jobs after merge.

## Change
- Gate deploy workflow on workflow_run.event == push
- Keep head_branch == main

This ensures CD executes only from successful CI push runs on main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined deployment conditions to ensure releases only occur on push events to the main branch, improving deployment reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->