### PR TITLE
fix(website): resolve Vercel deploy ERESOLVE on main

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -27,6 +27,6 @@
     "@types/react-dom": "^19.0.4",
     "typescript": "^5.0.0",
     "jest": "^29.0.0",
-    "@testing-library/react": "^14.0.0"
+    "@testing-library/react": "^16.3.0"
   }
 }


### PR DESCRIPTION
## Problem
Main-branch Deploy Main workflow runs, but website deploy fails during Vercel build with npm ERESOLVE.

## Root Cause
apps/website pins @testing-library/react@^14 which has peer react@^18, while website uses react@^19.

## Fix
- Upgrade apps/website devDependency:
  - @testing-library/react: ^14.0.0 -> ^16.3.0

## Expected Result
After merge to main, Deploy Main should proceed past website install/build and continue to admin deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing library dependency to the latest compatible version for improved test reliability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->