### PR TITLE
fix(admin): keep topic question modals above navbar

### DIFF
--- a/apps/admin/src/app/admin/content-management/page.integration.test.tsx
+++ b/apps/admin/src/app/admin/content-management/page.integration.test.tsx
@@ -102,7 +102,14 @@ vi.mock("@elzatona/common-ui", () => ({
     <div data-testid="delete-confirmation-modal" />
   ),
   CardManagementModal: () => <div data-testid="card-management-modal" />,
-  QuestionFormModal: () => <div data-testid="question-form-modal" />,
+  QuestionFormModal: ({ isOpen, readOnly, question }: any) =>
+    isOpen ? (
+      <div
+        data-testid="question-form-modal"
+        data-read-only={readOnly ? "true" : "false"}
+        data-question-id={question?.id ?? ""}
+      />
+    ) : null,
   CardFormModal: () => <div data-testid="card-form-modal" />,
 }));
 
@@ -274,5 +281,35 @@ describe("Admin content management page - Integration", () => {
     expect(screen.getByTestId("topic-questions-modal")).toBeInTheDocument();
     expect(screen.getByTestId("delete-confirmation-modal")).toBeInTheDocument();
     expect(screen.getByTestId("card-management-modal")).toBeInTheDocument();
+  });
+
+  it("passes read-only mode to question modal for view flow", () => {
+    mockUseContentManagement.mockReturnValue({
+      ...buildHookState(),
+      isQuestionModalOpen: true,
+      isQuestionReadOnly: true,
+      questionToEdit: { id: "q-view-1", title: "View only" },
+    });
+
+    render(<ContentManagementPage />);
+
+    const questionModal = screen.getByTestId("question-form-modal");
+    expect(questionModal).toHaveAttribute("data-read-only", "true");
+    expect(questionModal).toHaveAttribute("data-question-id", "q-view-1");
+  });
+
+  it("passes editable mode to question modal for edit flow", () => {
+    mockUseContentManagement.mockReturnValue({
+      ...buildHookState(),
+      isQuestionModalOpen: true,
+      isQuestionReadOnly: false,
+      questionToEdit: { id: "q-edit-1", title: "Editable" },
+    });
+
+    render(<ContentManagementPage />);
+
+    const questionModal = screen.getByTestId("question-form-modal");
+    expect(questionModal).toHaveAttribute("data-read-only", "false");
+    expect(questionModal).toHaveAttribute("data-question-id", "q-edit-1");
   });
 });

--- a/apps/admin/tests/e2e/admin/admin-content-management.spec.ts
+++ b/apps/admin/tests/e2e/admin/admin-content-management.spec.ts
@@ -286,6 +286,62 @@ test.describe("Admin Content Management Page", () => {
     }
   });
 
+  test("should open view and edit question modals above the fixed navbar", async ({
+    page,
+  }) => {
+    const planHeaders = page.locator('[id^="plan-"] .cursor-pointer');
+    const planCount = await planHeaders.count();
+    test.skip(planCount === 0, "No plans available in mocked dataset");
+
+    await planHeaders.first().click();
+
+    const planStructure = page.locator(
+      'div:has(> h4:has-text("Plan Structure"))',
+    );
+    await expect(planStructure).toBeVisible();
+
+    const cardHeader = planStructure
+      .locator('[id^="plan-card-"] .cursor-pointer')
+      .first();
+    await cardHeader.click();
+
+    const categoryHeader = planStructure
+      .locator('[id^="plan-category-"] .cursor-pointer')
+      .first();
+    await categoryHeader.click();
+
+    const topicHeader = planStructure
+      .locator('[id^="plan-topic-"] .cursor-pointer')
+      .first();
+    await topicHeader.click();
+
+    const viewButton = planStructure.locator('[title="View Question"]').first();
+    const editButton = planStructure.locator('[title="Edit Question"]').first();
+
+    await expect(viewButton).toBeVisible();
+    await expect(editButton).toBeVisible();
+
+    await viewButton.click();
+
+    const viewDialog = page.getByRole("dialog");
+    await expect(viewDialog).toBeVisible();
+    await expect(viewDialog).toHaveClass(/z-\[100\]/);
+    await expect(
+      page.getByRole("heading", { name: /View Question/i }),
+    ).toBeVisible();
+    await page.getByRole("button", { name: /Close dialog/i }).click();
+    await expect(viewDialog).not.toBeVisible({ timeout: 3000 });
+
+    await editButton.click();
+
+    const editDialog = page.getByRole("dialog");
+    await expect(editDialog).toBeVisible();
+    await expect(editDialog).toHaveClass(/z-\[100\]/);
+    await expect(
+      page.getByRole("heading", { name: /Edit Question/i }),
+    ).toBeVisible();
+  });
+
   // ─── Delete Confirmation Modal ───────────────────────────────────────────────
   test("should open Delete confirmation modal when delete card is clicked", async ({
     page,

--- a/libs/common-ui/src/admin/content-management/modals/QuestionFormModal.test.tsx
+++ b/libs/common-ui/src/admin/content-management/modals/QuestionFormModal.test.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { QuestionFormModal } from "./QuestionFormModal";
+import type { AdminUnifiedQuestion } from "@elzatona/types";
+
+vi.mock("../../questions/QuestionForm", () => ({
+  AdminQuestionForm: () => <div data-testid="admin-question-form" />,
+}));
+
+describe("QuestionFormModal", () => {
+  const sampleQuestion = {
+    id: "q-1",
+    title: "Question 1",
+  } as AdminUnifiedQuestion;
+
+  const defaultProps = {
+    isOpen: true,
+    onOpenChange: vi.fn(),
+    question: null,
+    cards: [],
+    allCategories: [],
+    onSubmit: vi.fn(async () => {}),
+  };
+
+  it("renders create mode by default", () => {
+    render(<QuestionFormModal {...defaultProps} />);
+
+    expect(
+      screen.getByRole("heading", { name: "Create New Question" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("dialog")).toHaveClass("z-[100]");
+  });
+
+  it("renders view mode when readOnly is true", () => {
+    render(
+      <QuestionFormModal
+        {...defaultProps}
+        readOnly
+        question={sampleQuestion}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "View Question" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders edit mode when question exists and readOnly is false", () => {
+    render(
+      <QuestionFormModal
+        {...defaultProps}
+        readOnly={false}
+        question={sampleQuestion}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Edit Question" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/libs/common-ui/src/components/ui/dialog.test.tsx
+++ b/libs/common-ui/src/components/ui/dialog.test.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { Dialog, DialogContent } from "./dialog";
+
+describe("Dialog", () => {
+  it("does not render when closed", () => {
+    render(
+      <Dialog open={false}>
+        <DialogContent>Hidden content</DialogContent>
+      </Dialog>,
+    );
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders with elevated stacking order when open", () => {
+    render(
+      <Dialog open>
+        <DialogContent>Visible content</DialogContent>
+      </Dialog>,
+    );
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveClass("z-[100]");
+  });
+
+  it("closes when the backdrop button is clicked", () => {
+    const onOpenChange = vi.fn();
+
+    render(
+      <Dialog open onOpenChange={onOpenChange}>
+        <DialogContent>Visible content</DialogContent>
+      </Dialog>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Close dialog" }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/libs/common-ui/src/components/ui/dialog.tsx
+++ b/libs/common-ui/src/components/ui/dialog.tsx
@@ -7,16 +7,20 @@ const Dialog = React.forwardRef<
     open?: boolean;
     onOpenChange?: (open: boolean) => void;
   }
->(({ className, open, onOpenChange, children, ...props }, ref) => {
+>(({ className: _className, open, onOpenChange, children, ...props }, ref) => {
   if (!open) return null;
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-6 py-8 overflow-y-auto"
+    <dialog
+      open
+      ref={ref}
+      className="fixed inset-0 z-[100] flex items-center justify-center p-4 sm:p-6 py-8 overflow-y-auto"
       style={{ backgroundColor: "rgba(0, 0, 0, 0.5)" }}
+      {...props}
     >
       <button
-        className="fixed inset-0 w-full h-full border-0 cursor-pointer bg-transparent -z-10"
+        type="button"
+        className="fixed inset-0 w-full h-full border-0 cursor-pointer bg-transparent"
         onClick={() => onOpenChange?.(false)}
         onKeyDown={(e) => {
           if (e.key === "Escape") {
@@ -28,7 +32,7 @@ const Dialog = React.forwardRef<
       />
       {/* We just render the children (usually DialogContent) directly here so we don't double loop the backgrounds */}
       {children}
-    </div>
+    </dialog>
   );
 });
 Dialog.displayName = "Dialog";
@@ -40,7 +44,7 @@ const DialogContent = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "relative z-50 w-full max-w-lg rounded-xl border bg-white dark:bg-gray-900 p-6 shadow-2xl flex flex-col my-8",
+      "relative z-[101] w-full max-w-lg rounded-xl border bg-white dark:bg-gray-900 p-6 shadow-2xl flex flex-col my-8",
       className,
     )}
     {...(props as any)}

--- a/libs/common-ui/src/components/ui/dialog.tsx
+++ b/libs/common-ui/src/components/ui/dialog.tsx
@@ -2,8 +2,8 @@ import * as React from "react";
 import { cn } from "../../utils";
 
 const Dialog = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & {
+  HTMLDialogElement,
+  React.HTMLAttributes<HTMLDialogElement> & {
     open?: boolean;
     onOpenChange?: (open: boolean) => void;
   }


### PR DESCRIPTION
## Summary\n- fix modal layering for topic question view/edit flows in content management so dialogs render above fixed navbar\n- add unit test coverage for dialog stacking and question form modal modes\n- add integration coverage for view/edit question modal prop wiring on content management page\n- add focused E2E coverage for topic question view/edit modal behavior and layering\n\n## Verification\n- npx vitest run libs/common-ui/src/components/ui/dialog.test.tsx libs/common-ui/src/admin/content-management/modals/QuestionFormModal.test.tsx apps/admin/src/app/admin/content-management/page.integration.test.tsx\n- npx playwright test apps/admin/tests/e2e/admin/admin-content-management.spec.ts --config=apps/admin/tests/config/playwright.config.ts --project=chromium --grep "view and edit question modals above the fixed navbar"\n\n## CI/CD behavior\n- PR runs CI checks only\n- CD remains triggered after merge to main via workflow_run gate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced dialog component with native HTML dialog element support for improved modal behavior and accessibility.

* **Bug Fixes**
  * Improved modal stacking order and z-index layering to prevent overlap issues with dialog components.

* **Tests**
  * Added comprehensive unit and integration test coverage for question form modal and dialog components, including view and edit flow validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->