### PR TITLE
fix(ci): prevent false deploy skips on main

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -53,7 +53,25 @@ jobs:
         run: |
           set -euo pipefail
 
-          CHANGED_FILES="$(git diff-tree --no-commit-id --name-only -r "${{ needs.gate-ci.outputs.head_sha }}")"
+          TARGET_SHA="${{ needs.gate-ci.outputs.head_sha }}"
+          PARENT_COUNT="$(git rev-list --parents -n 1 "$TARGET_SHA" | awk '{print NF-1}')"
+
+          if [ "$PARENT_COUNT" -ge 2 ]; then
+            # Merge commit on main: compare against first parent to include PR changes.
+            CHANGED_FILES="$(git diff --name-only "$TARGET_SHA^1" "$TARGET_SHA")"
+          else
+            # Regular commit on main.
+            CHANGED_FILES="$(git diff --name-only "$TARGET_SHA^" "$TARGET_SHA" || true)"
+          fi
+
+          if [ -z "$CHANGED_FILES" ]; then
+            # Defensive fallback: never skip both deploy targets because of detection failure.
+            echo "No changed files detected for $TARGET_SHA; forcing website/admin deploy to avoid false skip."
+            echo "website_changed=true" >> "$GITHUB_OUTPUT"
+            echo "admin_changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           echo "Changed files on main push:"
           echo "$CHANGED_FILES"
 

--- a/bun.lock
+++ b/bun.lock
@@ -123,7 +123,7 @@
     "immutable": "5.1.5",
     "jws": "3.2.3",
     "koa": "3.1.2",
-    "lodash": "4.17.23",
+    "lodash": "4.18.0",
     "lodash-es": "4.17.23",
     "monaco-editor": "0.53.0",
     "node-forge": "1.3.3",
@@ -3064,7 +3064,7 @@
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
-    "lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
+    "lodash": ["lodash@4.18.0", "", {}, "sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA=="],
 
     "lodash-es": ["lodash-es@4.17.23", "", {}, "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="],
 

--- a/package.json
+++ b/package.json
@@ -292,7 +292,7 @@
     "swagger-ui-react": {
       "immutable": "3.8.2"
     },
-    "lodash": "4.17.23",
+    "lodash": "4.18.0",
     "lodash-es": "4.17.23",
     "picomatch@^2.0.0": "2.3.2",
     "picomatch@^4.0.0": "4.0.4",


### PR DESCRIPTION
## Summary\nFix Deploy Main target detection so website/admin deployment jobs are not falsely skipped on merge commits.\n\n## Changes\n- Use merge-safe diff logic in deploy target detection\n- Add defensive fallback to avoid skipping both targets when changed files cannot be detected\n- Keep selective deployment behavior for actual changed targets\n\n## Validation\n- PR checks are green\n- Deploy workflow logic verified against previous skipped-run behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved deployment automation change-detection to better handle merge and standard commits and added fallback safeguards to avoid skipping deploy targets when detection fails.
  * Updated a dependency override for lodash to version 4.18.0 to keep packages current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->