### PR TITLE
fix(cd): stop stripping workspace dependencies before Vercel deploy

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -128,18 +128,6 @@ jobs:
           fi
           echo "VERCEL_TOKEN is configured"
 
-      - name: Prepare website package manifest for Vercel build
-        run: |
-          npm pkg delete --prefix apps/website dependencies.@elzatona/common-ui || true
-          npm pkg delete --prefix apps/website dependencies.@elzatona/contexts || true
-          npm pkg delete --prefix apps/website dependencies.@elzatona/database || true
-          npm pkg delete --prefix apps/website dependencies.@elzatona/types || true
-          npm pkg delete --prefix apps/website dependencies.@elzatona/utilities || true
-          npm pkg delete --prefix apps/website dependencies.@elzatona/hooks || true
-          npm pkg delete --prefix apps/website dependencies.@elzatona/shared-atoms || true
-          npm pkg delete --prefix apps/website dependencies.@elzatona/shared-components || true
-          rm -f apps/website/package-lock.json
-
       - name: Deploy website
         run: npx vercel deploy --prod --yes --cwd apps/website --token=${{ secrets.VERCEL_TOKEN }}
 
@@ -173,18 +161,6 @@ jobs:
             exit 1
           fi
           echo "VERCEL_TOKEN is configured"
-
-      - name: Prepare admin package manifest for Vercel build
-        run: |
-          npm pkg delete --prefix apps/admin dependencies.@elzatona/common-ui || true
-          npm pkg delete --prefix apps/admin dependencies.@elzatona/contexts || true
-          npm pkg delete --prefix apps/admin dependencies.@elzatona/database || true
-          npm pkg delete --prefix apps/admin dependencies.@elzatona/types || true
-          npm pkg delete --prefix apps/admin dependencies.@elzatona/utilities || true
-          npm pkg delete --prefix apps/admin dependencies.@elzatona/hooks || true
-          npm pkg delete --prefix apps/admin dependencies.@elzatona/shared-atoms || true
-          npm pkg delete --prefix apps/admin dependencies.@elzatona/shared-components || true
-          rm -f apps/admin/package-lock.json
 
       - name: Deploy admin
         run: npx vercel deploy --prod --yes --cwd apps/admin --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Problem
Main-branch Deploy Main runs were failing in both website and admin deploy jobs.

## Root Cause
The workflow was deleting internal workspace dependencies from app package manifests before Vercel build, which breaks monorepo app builds.

## Fix
- Keep workspace dependencies intact during deploy
- Rely on the app-level Vercel configs for build/install behavior

## Expected Result
Deploy Main should get past website/admin install and build again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the deployment workflow by removing unnecessary package manifest preparation steps during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->