### PR TITLE
fix(cd): force deploy website and admin on main

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -53,6 +53,13 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Temporary hotfix: deploy both apps on every successful main CI run.
+          # Restore selective detection in a follow-up PR after the deployment issue is resolved.
+          echo "website_changed=true" >> "$GITHUB_OUTPUT"
+          echo "admin_changed=true" >> "$GITHUB_OUTPUT"
+          echo "Changed files detection bypassed for forced deploy."
+          exit 0
+
           TARGET_SHA="${{ needs.gate-ci.outputs.head_sha }}"
           PARENT_COUNT="$(git rev-list --parents -n 1 "$TARGET_SHA" | awk '{print NF-1}')"
 


### PR DESCRIPTION
## Problem
Deploy Main is skipping website and admin when the merge only changes workflow files.

## Temporary Bypass
Force both deploy jobs to run on every successful main CI run.

## Follow-up
Create a separate PR to restore selective target detection after the deploy issue is resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to ensure services deploy when CI gates are satisfied, regardless of file change detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->