### PR TITLE
fix(cd): prevent Vercel npm 404 for internal deps

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -135,6 +135,10 @@ jobs:
           fi
           echo "VERCEL_TOKEN is configured"
 
+      - name: Prepare website package manifest for Vercel build
+        run: |
+          node -e 'const fs=require("fs");const p="apps/website/package.json";const pkg=JSON.parse(fs.readFileSync(p,"utf8"));const internal=["@elzatona/common-ui","@elzatona/contexts","@elzatona/database","@elzatona/types","@elzatona/utilities"];for(const name of internal){if(pkg.dependencies) delete pkg.dependencies[name]; if(pkg.devDependencies) delete pkg.devDependencies[name];} fs.writeFileSync(p, JSON.stringify(pkg, null, 2)+"\\n");'
+
       - name: Deploy website
         run: npx vercel deploy --prod --yes --cwd apps/website --token=${{ secrets.VERCEL_TOKEN }}
 
@@ -168,6 +172,10 @@ jobs:
             exit 1
           fi
           echo "VERCEL_TOKEN is configured"
+
+      - name: Prepare admin package manifest for Vercel build
+        run: |
+          node -e 'const fs=require("fs");const p="apps/admin/package.json";const pkg=JSON.parse(fs.readFileSync(p,"utf8"));const internal=["@elzatona/common-ui","@elzatona/contexts","@elzatona/database","@elzatona/types","@elzatona/utilities"];for(const name of internal){if(pkg.dependencies) delete pkg.dependencies[name]; if(pkg.devDependencies) delete pkg.devDependencies[name];} fs.writeFileSync(p, JSON.stringify(pkg, null, 2)+"\\n");'
 
       - name: Deploy admin
         run: npx vercel deploy --prod --yes --cwd apps/admin --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Problem
Deploy Main run 24025915962 fails for both website and admin during Vercel build install.

## Root Cause
Vercel remote install executes app-level npm install and attempts to fetch internal monorepo packages (for example @elzatona/common-ui) from npm registry, resulting in E404.

## Local Validation
- Verified locally that `npm view @elzatona/common-ui version` returns E404.
- Validated sanitize logic on temp package manifests: internal @elzatona/* deps are removed before deploy.

## Fix
- In .github/workflows/deploy-main.yml, add deploy-time manifest sanitization steps:
  - Prepare website package manifest for Vercel build
  - Prepare admin package manifest for Vercel build
- These steps remove internal @elzatona/* dependencies from app manifests before running vercel deploy.

## Expected Result
Vercel build install no longer fails on npm 404 for internal packages, allowing deploy jobs to proceed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment workflow to optimize package configuration during the build process for the website and admin applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->