### PR TITLE
fix(deploy): stabilize website/admin Vercel deploy on transient backend errors

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -151,15 +151,15 @@ jobs:
       - name: Deploy website
         run: |
           set -euo pipefail
-          npx vercel pull --yes --environment=production --cwd apps/website --token=${{ secrets.VERCEL_TOKEN }}
-          npx vercel build --prod --cwd apps/website --token=${{ secrets.VERCEL_TOKEN }}
+          timeout 8m npx vercel pull --yes --environment=production --cwd apps/website --token=${{ secrets.VERCEL_TOKEN }}
+          timeout 20m npx vercel build --prod --cwd apps/website --token=${{ secrets.VERCEL_TOKEN }}
           if [ ! -d "apps/website/.vercel/output" ]; then
             echo "Website prebuilt output missing at apps/website/.vercel/output"
             exit 1
           fi
           for attempt in 1 2 3 4 5 6; do
             echo "Deploy website attempt ${attempt}/6"
-            if npx vercel deploy --prebuilt --prod --yes --cwd apps/website --token=${{ secrets.VERCEL_TOKEN }}; then
+            if timeout 12m npx vercel deploy --prebuilt --prod --yes --cwd apps/website --token=${{ secrets.VERCEL_TOKEN }}; then
               exit 0
             fi
             if [ "$attempt" -eq 6 ]; then
@@ -215,15 +215,15 @@ jobs:
       - name: Deploy admin
         run: |
           set -euo pipefail
-          npx vercel pull --yes --environment=production --cwd apps/admin --token=${{ secrets.VERCEL_TOKEN }}
-          npx vercel build --prod --cwd apps/admin --token=${{ secrets.VERCEL_TOKEN }}
+          timeout 8m npx vercel pull --yes --environment=production --cwd apps/admin --token=${{ secrets.VERCEL_TOKEN }}
+          timeout 20m npx vercel build --prod --cwd apps/admin --token=${{ secrets.VERCEL_TOKEN }}
           if [ ! -d "apps/admin/.vercel/output" ]; then
             echo "Admin prebuilt output missing at apps/admin/.vercel/output"
             exit 1
           fi
           for attempt in 1 2 3 4 5 6; do
             echo "Deploy admin attempt ${attempt}/6"
-            if npx vercel deploy --prebuilt --prod --yes --cwd apps/admin --token=${{ secrets.VERCEL_TOKEN }}; then
+            if timeout 12m npx vercel deploy --prebuilt --prod --yes --cwd apps/admin --token=${{ secrets.VERCEL_TOKEN }}; then
               exit 0
             fi
             if [ "$attempt" -eq 6 ]; then

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -151,16 +151,24 @@ jobs:
       - name: Deploy website
         run: |
           set -euo pipefail
-          for attempt in 1 2 3; do
-            echo "Deploy website attempt ${attempt}/3"
-            if npx vercel deploy --prod --yes --cwd apps/website --token=${{ secrets.VERCEL_TOKEN }}; then
+          npx vercel pull --yes --environment=production --cwd apps/website --token=${{ secrets.VERCEL_TOKEN }}
+          npx vercel build --prod --cwd apps/website --token=${{ secrets.VERCEL_TOKEN }}
+          if [ ! -d "apps/website/.vercel/output" ]; then
+            echo "Website prebuilt output missing at apps/website/.vercel/output"
+            exit 1
+          fi
+          for attempt in 1 2 3 4 5 6; do
+            echo "Deploy website attempt ${attempt}/6"
+            if npx vercel deploy --prebuilt --prod --yes --cwd apps/website --token=${{ secrets.VERCEL_TOKEN }}; then
               exit 0
             fi
-            if [ "$attempt" -eq 3 ]; then
-              echo "Website deployment failed after 3 attempts"
+            if [ "$attempt" -eq 6 ]; then
+              echo "Website deployment failed after 6 attempts"
               exit 1
             fi
-            echo "Retrying website deploy after transient failure..."
+            sleep_seconds=$((attempt * 15))
+            echo "Retrying website deploy after transient failure in ${sleep_seconds}s..."
+            sleep "$sleep_seconds"
           done
 
   deploy-admin:
@@ -207,14 +215,22 @@ jobs:
       - name: Deploy admin
         run: |
           set -euo pipefail
-          for attempt in 1 2 3; do
-            echo "Deploy admin attempt ${attempt}/3"
-            if npx vercel deploy --prod --yes --cwd apps/admin --token=${{ secrets.VERCEL_TOKEN }}; then
+          npx vercel pull --yes --environment=production --cwd apps/admin --token=${{ secrets.VERCEL_TOKEN }}
+          npx vercel build --prod --cwd apps/admin --token=${{ secrets.VERCEL_TOKEN }}
+          if [ ! -d "apps/admin/.vercel/output" ]; then
+            echo "Admin prebuilt output missing at apps/admin/.vercel/output"
+            exit 1
+          fi
+          for attempt in 1 2 3 4 5 6; do
+            echo "Deploy admin attempt ${attempt}/6"
+            if npx vercel deploy --prebuilt --prod --yes --cwd apps/admin --token=${{ secrets.VERCEL_TOKEN }}; then
               exit 0
             fi
-            if [ "$attempt" -eq 3 ]; then
-              echo "Admin deployment failed after 3 attempts"
+            if [ "$attempt" -eq 6 ]; then
+              echo "Admin deployment failed after 6 attempts"
               exit 1
             fi
-            echo "Retrying admin deploy after transient failure..."
+            sleep_seconds=$((attempt * 15))
+            echo "Retrying admin deploy after transient failure in ${sleep_seconds}s..."
+            sleep "$sleep_seconds"
           done

--- a/.github/workflows/manual-deploy-parallel.yml
+++ b/.github/workflows/manual-deploy-parallel.yml
@@ -93,16 +93,24 @@ jobs:
       - name: Deploy website to Vercel
         run: |
           set -euo pipefail
-          for attempt in 1 2 3; do
-            echo "Deploy website attempt ${attempt}/3"
-            if npx vercel deploy --prod --yes --cwd apps/website --token=${{ secrets.VERCEL_TOKEN }}; then
+          npx vercel pull --yes --environment=production --cwd apps/website --token=${{ secrets.VERCEL_TOKEN }}
+          npx vercel build --prod --cwd apps/website --token=${{ secrets.VERCEL_TOKEN }}
+          if [ ! -d "apps/website/.vercel/output" ]; then
+            echo "Website prebuilt output missing at apps/website/.vercel/output"
+            exit 1
+          fi
+          for attempt in 1 2 3 4 5 6; do
+            echo "Deploy website attempt ${attempt}/6"
+            if npx vercel deploy --prebuilt --prod --yes --cwd apps/website --token=${{ secrets.VERCEL_TOKEN }}; then
               exit 0
             fi
-            if [ "$attempt" -eq 3 ]; then
-              echo "Website deployment failed after 3 attempts"
+            if [ "$attempt" -eq 6 ]; then
+              echo "Website deployment failed after 6 attempts"
               exit 1
             fi
-            echo "Retrying website deploy after transient failure..."
+            sleep_seconds=$((attempt * 15))
+            echo "Retrying website deploy after transient failure in ${sleep_seconds}s..."
+            sleep "$sleep_seconds"
           done
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -166,16 +174,24 @@ jobs:
       - name: Deploy admin to Vercel
         run: |
           set -euo pipefail
-          for attempt in 1 2 3; do
-            echo "Deploy admin attempt ${attempt}/3"
-            if npx vercel deploy --prod --yes --cwd apps/admin --token=${{ secrets.VERCEL_TOKEN }}; then
+          npx vercel pull --yes --environment=production --cwd apps/admin --token=${{ secrets.VERCEL_TOKEN }}
+          npx vercel build --prod --cwd apps/admin --token=${{ secrets.VERCEL_TOKEN }}
+          if [ ! -d "apps/admin/.vercel/output" ]; then
+            echo "Admin prebuilt output missing at apps/admin/.vercel/output"
+            exit 1
+          fi
+          for attempt in 1 2 3 4 5 6; do
+            echo "Deploy admin attempt ${attempt}/6"
+            if npx vercel deploy --prebuilt --prod --yes --cwd apps/admin --token=${{ secrets.VERCEL_TOKEN }}; then
               exit 0
             fi
-            if [ "$attempt" -eq 3 ]; then
-              echo "Admin deployment failed after 3 attempts"
+            if [ "$attempt" -eq 6 ]; then
+              echo "Admin deployment failed after 6 attempts"
               exit 1
             fi
-            echo "Retrying admin deploy after transient failure..."
+            sleep_seconds=$((attempt * 15))
+            echo "Retrying admin deploy after transient failure in ${sleep_seconds}s..."
+            sleep "$sleep_seconds"
           done
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}

--- a/.github/workflows/manual-deploy-parallel.yml
+++ b/.github/workflows/manual-deploy-parallel.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Validate build locally (optional build check)
         if: ${{ inputs.validate_build_website }}
-        run: pnpm run build
+        run: pnpm --dir apps/website run build
         env:
           NEXT_PUBLIC_APP_ENV: production
           NEXT_TELEMETRY_DISABLED: 1
@@ -157,7 +157,7 @@ jobs:
 
       - name: Validate build locally (optional build check)
         if: ${{ inputs.validate_build_admin }}
-        run: pnpm run build:admin
+        run: pnpm --dir apps/admin run build
         env:
           NEXT_PUBLIC_APP_ENV: production
           NEXT_TELEMETRY_DISABLED: 1

--- a/.github/workflows/manual-deploy-parallel.yml
+++ b/.github/workflows/manual-deploy-parallel.yml
@@ -93,15 +93,15 @@ jobs:
       - name: Deploy website to Vercel
         run: |
           set -euo pipefail
-          npx vercel pull --yes --environment=production --cwd apps/website --token=${{ secrets.VERCEL_TOKEN }}
-          npx vercel build --prod --cwd apps/website --token=${{ secrets.VERCEL_TOKEN }}
+          timeout 8m npx vercel pull --yes --environment=production --cwd apps/website --token=${{ secrets.VERCEL_TOKEN }}
+          timeout 20m npx vercel build --prod --cwd apps/website --token=${{ secrets.VERCEL_TOKEN }}
           if [ ! -d "apps/website/.vercel/output" ]; then
             echo "Website prebuilt output missing at apps/website/.vercel/output"
             exit 1
           fi
           for attempt in 1 2 3 4 5 6; do
             echo "Deploy website attempt ${attempt}/6"
-            if npx vercel deploy --prebuilt --prod --yes --cwd apps/website --token=${{ secrets.VERCEL_TOKEN }}; then
+            if timeout 12m npx vercel deploy --prebuilt --prod --yes --cwd apps/website --token=${{ secrets.VERCEL_TOKEN }}; then
               exit 0
             fi
             if [ "$attempt" -eq 6 ]; then
@@ -174,15 +174,15 @@ jobs:
       - name: Deploy admin to Vercel
         run: |
           set -euo pipefail
-          npx vercel pull --yes --environment=production --cwd apps/admin --token=${{ secrets.VERCEL_TOKEN }}
-          npx vercel build --prod --cwd apps/admin --token=${{ secrets.VERCEL_TOKEN }}
+          timeout 8m npx vercel pull --yes --environment=production --cwd apps/admin --token=${{ secrets.VERCEL_TOKEN }}
+          timeout 20m npx vercel build --prod --cwd apps/admin --token=${{ secrets.VERCEL_TOKEN }}
           if [ ! -d "apps/admin/.vercel/output" ]; then
             echo "Admin prebuilt output missing at apps/admin/.vercel/output"
             exit 1
           fi
           for attempt in 1 2 3 4 5 6; do
             echo "Deploy admin attempt ${attempt}/6"
-            if npx vercel deploy --prebuilt --prod --yes --cwd apps/admin --token=${{ secrets.VERCEL_TOKEN }}; then
+            if timeout 12m npx vercel deploy --prebuilt --prod --yes --cwd apps/admin --token=${{ secrets.VERCEL_TOKEN }}; then
               exit 0
             fi
             if [ "$attempt" -eq 6 ]; then

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",
-    "build": "next build",
+    "build": "next build --webpack",
     "start": "next start -p 3001",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },

--- a/apps/admin/vercel.json
+++ b/apps/admin/vercel.json
@@ -1,5 +1,7 @@
 {
   "framework": "nextjs",
+  "buildCommand": "npm run build",
+  "outputDirectory": ".next",
   "env": {
     "NODE_ENV": "production"
   },

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "test": "jest",

--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -1,5 +1,7 @@
 {
   "framework": "nextjs",
+  "buildCommand": "npm run build",
+  "outputDirectory": ".next",
   "env": {
     "NODE_ENV": "production"
   },


### PR DESCRIPTION
## Problem
Manual deploy run 24294735290 fails for both Website and Admin after successful local build because Vercel returns transient backend error: "Unexpected error. Please try again later."

## Root Cause
Deploy jobs treated intermittent Vercel backend failures as hard failures after only 3 attempts, and repeated expensive prebuild work on every retry.

## Fix
- Keep prebuilt flow (vercel pull + vercel build) once per job
- Validate .vercel/output exists before deploy
- Retry only vercel deploy --prebuilt up to 6 attempts
- Add linear backoff (attempt * 15s) between retries
- Apply to both workflows:
  - .github/workflows/manual-deploy-parallel.yml
  - .github/workflows/deploy-main.yml

## Expected Result
Deploy jobs are resilient to transient Vercel backend errors and complete without false negatives.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved deployment flow with an explicit prebuild/check step and verification of prebuilt output.
  * Increased retry attempts and added progressive backoff between attempts for more reliable deployments.
  * Updated build invocations for both website and admin apps.
  * Added explicit build and output configuration for both apps' deployment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->