### PR TITLE
fix(admin): align badge rails and fullscreen question modal

### DIFF
--- a/libs/common-ui/src/admin/content-management/LearningCardsManager.test.tsx
+++ b/libs/common-ui/src/admin/content-management/LearningCardsManager.test.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { LearningCardsManager } from "./LearningCardsManager";
+import type {
+  AdminCategory,
+  AdminLearningCard,
+  AdminUnifiedQuestion,
+  ContentManagementStats,
+  Topic,
+} from "@elzatona/types";
+
+describe("LearningCardsManager", () => {
+  it("keeps topic and category badges fixed on the right", () => {
+    const cards = [
+      {
+        id: "card-1",
+        title: "Core Technologies",
+        description: "Main learning card",
+        color: "#3B82F6",
+      } as AdminLearningCard,
+    ];
+    const categories = [
+      {
+        id: "category-1",
+        name: "JavaScript Programming",
+        description: "Language basics",
+        learning_card_id: "card-1",
+      } as AdminCategory,
+    ];
+    const topics = [
+      {
+        id: "topic-1",
+        name: "JavaScript Core Concepts",
+        description: "Functions and objects",
+        category_id: "category-1",
+      } as Topic,
+    ];
+    const questions = [
+      {
+        id: "question-1",
+        title: "Question 1",
+        topic_id: "topic-1",
+      } as AdminUnifiedQuestion,
+    ];
+    const stats = {
+      totalCards: 1,
+      totalPlans: 0,
+      totalCategories: 1,
+      totalTopics: 1,
+      totalQuestions: 1,
+    } as ContentManagementStats;
+
+    const { container } = render(
+      <LearningCardsManager
+        cards={cards}
+        categories={categories}
+        topics={topics}
+        questions={questions}
+        stats={stats}
+        expandedCards={new Set(["card-1"])}
+        toggleCard={() => {}}
+        expandedCategories={new Set(["category-1"])}
+        toggleCategory={() => {}}
+        expandedTopics={new Set(["topic-1"])}
+        toggleTopic={() => {}}
+        onEditCard={() => {}}
+        onDeleteCard={() => {}}
+        onCreateCard={() => {}}
+        onEditCategories={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("Learning Cards (1)")).toBeInTheDocument();
+    expect(screen.getByText("1 Categories")).toBeInTheDocument();
+    expect(screen.getAllByText("1 Topics")).toHaveLength(2);
+    expect(screen.getAllByText("1 Questions")).toHaveLength(2);
+
+    const topicRow = container.querySelector("#topic-topic-1 > div");
+    const categoryRow = container.querySelector(
+      "#category-category-1 > button",
+    );
+
+    expect(topicRow).toHaveClass("items-start");
+    expect(topicRow).toHaveClass("justify-between");
+    expect(topicRow?.children[1]).toHaveClass("shrink-0");
+
+    expect(categoryRow).toHaveClass("items-start");
+    expect(categoryRow).toHaveClass("justify-between");
+  });
+});

--- a/libs/common-ui/src/admin/content-management/LearningCardsManager.tsx
+++ b/libs/common-ui/src/admin/content-management/LearningCardsManager.tsx
@@ -118,10 +118,10 @@ const TopicNode: React.FC<{
       id={`topic-${topic.id}`}
       className="border-l-2 border-gray-100 pl-4 py-2"
     >
-      <div className="flex items-center justify-between p-2 rounded transition-colors hover:bg-gray-50 dark:hover:bg-gray-800">
+      <div className="flex items-start justify-between gap-4 p-2 rounded transition-colors hover:bg-gray-50 dark:hover:bg-gray-800">
         <button
           type="button"
-          className="flex items-center space-x-2 text-left flex-1"
+          className="flex min-w-0 flex-1 items-start space-x-2 text-left"
           onClick={() => toggleTopic(topic.id)}
         >
           <div className="p-1">
@@ -132,17 +132,17 @@ const TopicNode: React.FC<{
             )}
           </div>
           <Target className="h-4 w-4 text-orange-600" />
-          <div>
+          <div className="min-w-0 text-left">
             <h5 className="font-medium">{topic.name}</h5>
             <p className="text-sm text-gray-600 dark:text-gray-400">
               {topic.description}
             </p>
           </div>
         </button>
-        <div className="flex items-center space-x-2">
+        <div className="flex shrink-0 items-center space-x-2">
           <Badge
             variant="outline"
-            className="bg-green-50 text-green-700 dark:bg-green-900 dark:text-green-300"
+            className="shrink-0 whitespace-nowrap bg-green-50 text-green-700 dark:bg-green-900 dark:text-green-300"
           >
             {topicQuestions.length} Questions
           </Badge>
@@ -248,10 +248,10 @@ const CategoryNode: React.FC<{
     >
       <button
         type="button"
-        className="flex items-center justify-between py-2 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 p-2 rounded transition-colors"
+        className="flex items-start justify-between gap-4 py-2 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 p-2 rounded transition-colors"
         onClick={() => toggleCategory(category.id)}
       >
-        <div className="flex items-center space-x-2">
+        <div className="flex min-w-0 flex-1 items-start space-x-2">
           <div className="p-1">
             {expandedCategories.has(category.id) ? (
               <ChevronDown className="h-4 w-4 text-gray-500" />
@@ -260,17 +260,17 @@ const CategoryNode: React.FC<{
             )}
           </div>
           <BookOpen className="h-4 w-4 text-purple-600" />
-          <div>
+          <div className="min-w-0 text-left">
             <h4 className="font-medium">{category.name}</h4>
             <p className="text-sm text-gray-600 dark:text-gray-400">
               {category.description}
             </p>
           </div>
         </div>
-        <div className="flex items-center space-x-2">
+        <div className="flex shrink-0 items-center space-x-2">
           <Badge
             variant="outline"
-            className="bg-purple-50 text-purple-700 dark:bg-purple-900 dark:text-purple-300"
+            className="shrink-0 whitespace-nowrap bg-purple-50 text-purple-700 dark:bg-purple-900 dark:text-purple-300"
           >
             {categoryTopics.length} Topics
           </Badge>
@@ -359,7 +359,7 @@ export const LearningCardsManager: React.FC<LearningCardsManagerProps> = ({
           <div className="flex items-center justify-between">
             <button
               type="button"
-              className="flex items-center space-x-3 text-left flex-1"
+              className="flex min-w-0 flex-1 items-start space-x-3 text-left"
               onClick={() => toggleCard(card.id)}
             >
               <div className="p-1 rounded group-hover:bg-gray-200 dark:group-hover:bg-gray-700 transition-colors">
@@ -373,7 +373,7 @@ export const LearningCardsManager: React.FC<LearningCardsManagerProps> = ({
                 className="h-5 w-5"
                 style={{ color: card.color }}
               />
-              <div>
+              <div className="min-w-0 text-left">
                 <CardTitle className="text-lg group-hover:text-blue-600 transition-colors">
                   {card.title}
                 </CardTitle>
@@ -382,22 +382,22 @@ export const LearningCardsManager: React.FC<LearningCardsManagerProps> = ({
                 </p>
               </div>
             </button>
-            <div className="flex items-center space-x-2">
+            <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
               <Badge
                 variant="outline"
-                className="bg-blue-50 text-blue-700 dark:bg-blue-900 dark:text-blue-300"
+                className="shrink-0 whitespace-nowrap bg-blue-50 text-blue-700 dark:bg-blue-900 dark:text-blue-300"
               >
                 {cardCategories.length} Categories
               </Badge>
               <Badge
                 variant="outline"
-                className="bg-purple-50 text-purple-700 dark:bg-purple-900 dark:text-purple-300"
+                className="shrink-0 whitespace-nowrap bg-purple-50 text-purple-700 dark:bg-purple-900 dark:text-purple-300"
               >
                 {countTopicsForCategories(cardCategories, topics)} Topics
               </Badge>
               <Badge
                 variant="outline"
-                className="bg-green-50 text-green-700 dark:bg-green-900 dark:text-green-300"
+                className="shrink-0 whitespace-nowrap bg-green-50 text-green-700 dark:bg-green-900 dark:text-green-300"
               >
                 {countQuestionsForCategories(cardCategories, topics, questions)}{" "}
                 Questions

--- a/libs/common-ui/src/admin/content-management/modals/QuestionFormModal.test.tsx
+++ b/libs/common-ui/src/admin/content-management/modals/QuestionFormModal.test.tsx
@@ -25,12 +25,14 @@ describe("QuestionFormModal", () => {
   };
 
   it("renders create mode by default", () => {
-    render(<QuestionFormModal {...defaultProps} />);
+    const { container } = render(<QuestionFormModal {...defaultProps} />);
 
     expect(
       screen.getByRole("heading", { name: "Create New Question" }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("dialog")).toHaveClass("z-[100]");
+    expect(screen.getByRole("dialog")).toHaveClass("z-[200]");
+    expect(container.querySelector("dialog > div")).toHaveClass("h-[100dvh]");
+    expect(container.querySelector("dialog > div")).toHaveClass("w-[100vw]");
   });
 
   it("renders view mode when readOnly is true", () => {

--- a/libs/common-ui/src/admin/content-management/modals/QuestionFormModal.tsx
+++ b/libs/common-ui/src/admin/content-management/modals/QuestionFormModal.tsx
@@ -38,40 +38,42 @@ export const QuestionFormModal: React.FC<QuestionFormModalProps> = ({
 }) => {
   const initialData =
     question || (topicId ? ({ topic_id: topicId } as any) : undefined);
+  let modalTitle = "Create New Question";
+  if (readOnly) {
+    modalTitle = "View Question";
+  } else if (question) {
+    modalTitle = "Edit Question";
+  }
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle className="flex items-center space-x-2">
-            <HelpCircle className="h-5 w-5 text-blue-600" />
-            <span>
-              {readOnly
-                ? "View Question"
-                : question
-                  ? "Edit Question"
-                  : "Create New Question"}
-            </span>
-          </DialogTitle>
-        </DialogHeader>
+      <DialogContent className="z-[200] h-[100dvh] w-[100vw] max-w-none overflow-hidden rounded-none border-0 p-0">
+        <div className="flex h-full flex-col bg-white dark:bg-gray-900">
+          <DialogHeader className="px-6 pt-6 pb-4 flex-shrink-0">
+            <DialogTitle className="flex items-center space-x-2">
+              <HelpCircle className="h-5 w-5 text-blue-600" />
+              <span>{modalTitle}</span>
+            </DialogTitle>
+          </DialogHeader>
 
-        <div className="py-4">
-          <AdminQuestionForm
-            initialData={initialData}
-            onSubmit={async (data) => {
-              await onSubmit(data);
-            }}
-            onCancel={() => onOpenChange(false)}
-            cards={cards}
-            allCategories={allCategories}
-            allTags={allTags}
-            readOnly={readOnly}
-          />
-          {isLoading && (
-            <div className="absolute inset-0 bg-white/50 flex items-center justify-center z-50">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
-            </div>
-          )}
+          <div className="relative flex-1 overflow-y-auto px-6 py-4">
+            <AdminQuestionForm
+              initialData={initialData}
+              onSubmit={async (data) => {
+                await onSubmit(data);
+              }}
+              onCancel={() => onOpenChange(false)}
+              cards={cards}
+              allCategories={allCategories}
+              allTags={allTags}
+              readOnly={readOnly}
+            />
+            {isLoading && (
+              <div className="absolute inset-0 bg-white/50 flex items-center justify-center z-50">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+              </div>
+            )}
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/libs/common-ui/src/components/ui/dialog.test.tsx
+++ b/libs/common-ui/src/components/ui/dialog.test.tsx
@@ -32,7 +32,7 @@ describe("Dialog", () => {
 
     const dialog = screen.getByRole("dialog");
     expect(dialog).toBeInTheDocument();
-    expect(dialog).toHaveClass("z-[100]");
+    expect(dialog).toHaveClass("z-[200]");
   });
 
   it("closes when the backdrop button is clicked", () => {

--- a/libs/common-ui/src/components/ui/dialog.tsx
+++ b/libs/common-ui/src/components/ui/dialog.tsx
@@ -14,7 +14,7 @@ const Dialog = React.forwardRef<
     <dialog
       open
       ref={ref}
-      className="fixed inset-0 z-[100] flex items-center justify-center p-4 sm:p-6 py-8 overflow-y-auto"
+      className="fixed inset-0 z-[200] flex items-center justify-center p-4 sm:p-6 py-8 overflow-y-auto"
       style={{ backgroundColor: "rgba(0, 0, 0, 0.5)" }}
       {...props}
     >
@@ -44,7 +44,7 @@ const DialogContent = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "relative z-[101] w-full max-w-lg rounded-xl border bg-white dark:bg-gray-900 p-6 shadow-2xl flex flex-col my-8",
+      "relative z-[201] w-full max-w-lg rounded-xl border bg-white dark:bg-gray-900 p-6 shadow-2xl flex flex-col my-8",
       className,
     )}
     {...(props as any)}


### PR DESCRIPTION
## Summary
- keep learning-card topic/category badges fixed on the right while left text stays left-aligned
- expand the question modal to full-screen and keep it above the admin navbar
- update dialog stacking and add focused tests for the new layout

## Validation
- npx vitest run libs/common-ui/src/admin/content-management/modals/QuestionFormModal.test.tsx libs/common-ui/src/admin/content-management/LearningCardsManager.test.tsx libs/common-ui/src/components/ui/dialog.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive test coverage for the Learning Cards manager component.

* **Bug Fixes**
  * Redesigned modal dialogs to fullscreen presentation for improved visibility and usability.
  * Improved layout spacing and overflow handling in content management interface with better visual hierarchy and fixed badge positioning.
  * Adjusted dialog stacking context for proper layering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->