### PR TITLE
fix(deploy): run vercel from repo root for monorepo builds

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -157,11 +157,11 @@ jobs:
       - name: Deploy website
         run: |
           set -euo pipefail
-          timeout 8m npx vercel pull --yes --environment=production --cwd apps/website --token=${{ secrets.VERCEL_TOKEN }}
+          timeout 8m npx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
           for attempt in 1 2 3 4 5 6; do
             echo "Deploy website attempt ${attempt}/6"
             deploy_log="$(mktemp)"
-            timeout 20m npx vercel deploy --prod --yes --cwd apps/website --token=${{ secrets.VERCEL_TOKEN }} 2>&1 | tee "$deploy_log" || true
+            timeout 20m npx vercel deploy --prod --yes --token=${{ secrets.VERCEL_TOKEN }} 2>&1 | tee "$deploy_log" || true
             if grep -Eq 'Failed to process project graph|Could not find ".modules.yaml"|ENOENT: no such file or directory|Error: Command "npx nx build|Error: Command "npm run build" exited with 1|Error: Command "npm install" exited with 1' "$deploy_log"; then
               echo "Deploy output indicates explicit build failure; failing deployment step."
               exit 1
@@ -252,11 +252,11 @@ jobs:
       - name: Deploy admin
         run: |
           set -euo pipefail
-          timeout 8m npx vercel pull --yes --environment=production --cwd apps/admin --token=${{ secrets.VERCEL_TOKEN }}
+          timeout 8m npx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
           for attempt in 1 2 3 4 5 6; do
             echo "Deploy admin attempt ${attempt}/6"
             deploy_log="$(mktemp)"
-            timeout 20m npx vercel deploy --prod --yes --cwd apps/admin --token=${{ secrets.VERCEL_TOKEN }} 2>&1 | tee "$deploy_log" || true
+            timeout 20m npx vercel deploy --prod --yes --token=${{ secrets.VERCEL_TOKEN }} 2>&1 | tee "$deploy_log" || true
             if grep -Eq 'Failed to process project graph|Could not find ".modules.yaml"|ENOENT: no such file or directory|Error: Command "npx nx build|Error: Command "npm run build" exited with 1|Error: Command "npm install" exited with 1' "$deploy_log"; then
               echo "Deploy output indicates explicit build failure; failing deployment step."
               exit 1

--- a/.github/workflows/manual-deploy-parallel.yml
+++ b/.github/workflows/manual-deploy-parallel.yml
@@ -96,11 +96,11 @@ jobs:
       - name: Deploy website to Vercel
         run: |
           set -euo pipefail
-          timeout 8m npx vercel pull --yes --environment=production --cwd apps/website --token=${{ secrets.VERCEL_TOKEN }}
+          timeout 8m npx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
           for attempt in 1 2 3 4 5 6; do
             echo "Deploy website attempt ${attempt}/6"
             deploy_log="$(mktemp)"
-            timeout 20m npx vercel deploy --prod --yes --cwd apps/website --token=${{ secrets.VERCEL_TOKEN }} 2>&1 | tee "$deploy_log" || true
+            timeout 20m npx vercel deploy --prod --yes --token=${{ secrets.VERCEL_TOKEN }} 2>&1 | tee "$deploy_log" || true
             if grep -Eq 'Failed to process project graph|Could not find ".modules.yaml"|ENOENT: no such file or directory|Error: Command "npx nx build|Error: Command "npm run build" exited with 1|Error: Command "npm install" exited with 1' "$deploy_log"; then
               echo "Deploy output indicates explicit build failure; failing deployment step."
               exit 1
@@ -205,11 +205,11 @@ jobs:
       - name: Deploy admin to Vercel
         run: |
           set -euo pipefail
-          timeout 8m npx vercel pull --yes --environment=production --cwd apps/admin --token=${{ secrets.VERCEL_TOKEN }}
+          timeout 8m npx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
           for attempt in 1 2 3 4 5 6; do
             echo "Deploy admin attempt ${attempt}/6"
             deploy_log="$(mktemp)"
-            timeout 20m npx vercel deploy --prod --yes --cwd apps/admin --token=${{ secrets.VERCEL_TOKEN }} 2>&1 | tee "$deploy_log" || true
+            timeout 20m npx vercel deploy --prod --yes --token=${{ secrets.VERCEL_TOKEN }} 2>&1 | tee "$deploy_log" || true
             if grep -Eq 'Failed to process project graph|Could not find ".modules.yaml"|ENOENT: no such file or directory|Error: Command "npx nx build|Error: Command "npm run build" exited with 1|Error: Command "npm install" exited with 1' "$deploy_log"; then
               echo "Deploy output indicates explicit build failure; failing deployment step."
               exit 1


### PR DESCRIPTION
## Summary\n- run Vercel pull/deploy from repository root (remove app-level --cwd)\n- preserve monorepo root config visibility during remote build\n- keep project targeting via VERCEL_PROJECT_ID env vars\n\n## Why\nRecent production manual deploy on main (run 24472380086) failed in both jobs with:\n- Cannot read file '/tsconfig.base.json'\n- Cannot read file '/tsconfig.json'\n\nThis indicates app-only upload context during remote build. Deploying from repo root restores access to root tsconfig and monorepo files.