### PR TITLE
fix(deploy): run app build directly from vercel root

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -154,6 +154,10 @@ jobs:
         run: |
           node -e 'const fs=require("fs");const root=JSON.parse(fs.readFileSync("package.json","utf8"));const p="apps/website/package.json";const pkg=JSON.parse(fs.readFileSync(p,"utf8"));const internal=["@elzatona/common-ui","@elzatona/contexts","@elzatona/database","@elzatona/types","@elzatona/utilities"];const required=["@sentry/nextjs"];pkg.dependencies=pkg.dependencies||{};for(const name of internal){if(pkg.dependencies) delete pkg.dependencies[name]; if(pkg.devDependencies) delete pkg.devDependencies[name];}for(const name of required){if(!pkg.dependencies[name]){const v=(root.dependencies&&root.dependencies[name])||(root.devDependencies&&root.devDependencies[name]);if(v) pkg.dependencies[name]=v;}}fs.writeFileSync(p, JSON.stringify(pkg, null, 2)+"\n");'
 
+      - name: Set root build script for website deployment
+        run: |
+          node -e 'const fs=require("fs");const p="package.json";const pkg=JSON.parse(fs.readFileSync(p,"utf8"));pkg.scripts=pkg.scripts||{};pkg.scripts.build="pnpm --dir apps/website build";fs.writeFileSync(p, JSON.stringify(pkg, null, 2)+"\n");'
+
       - name: Deploy website
         run: |
           set -euo pipefail
@@ -248,6 +252,10 @@ jobs:
       - name: Prepare admin package manifest for Vercel build
         run: |
           node -e 'const fs=require("fs");const root=JSON.parse(fs.readFileSync("package.json","utf8"));const p="apps/admin/package.json";const pkg=JSON.parse(fs.readFileSync(p,"utf8"));const internal=["@elzatona/common-ui","@elzatona/contexts","@elzatona/database","@elzatona/types","@elzatona/utilities"];const required=["@sentry/nextjs"];pkg.dependencies=pkg.dependencies||{};for(const name of internal){if(pkg.dependencies) delete pkg.dependencies[name]; if(pkg.devDependencies) delete pkg.devDependencies[name];}for(const name of required){if(!pkg.dependencies[name]){const v=(root.dependencies&&root.dependencies[name])||(root.devDependencies&&root.devDependencies[name]);if(v) pkg.dependencies[name]=v;}}fs.writeFileSync(p, JSON.stringify(pkg, null, 2)+"\n");'
+
+      - name: Set root build script for admin deployment
+        run: |
+          node -e 'const fs=require("fs");const p="package.json";const pkg=JSON.parse(fs.readFileSync(p,"utf8"));pkg.scripts=pkg.scripts||{};pkg.scripts.build="pnpm --dir apps/admin build";fs.writeFileSync(p, JSON.stringify(pkg, null, 2)+"\n");'
 
       - name: Deploy admin
         run: |

--- a/.github/workflows/manual-deploy-parallel.yml
+++ b/.github/workflows/manual-deploy-parallel.yml
@@ -93,6 +93,10 @@ jobs:
         run: |
           node -e 'const fs=require("fs");const root=JSON.parse(fs.readFileSync("package.json","utf8"));const p="apps/website/package.json";const pkg=JSON.parse(fs.readFileSync(p,"utf8"));const internal=["@elzatona/common-ui","@elzatona/contexts","@elzatona/database","@elzatona/types","@elzatona/utilities"];const required=["@sentry/nextjs"];pkg.dependencies=pkg.dependencies||{};for(const name of internal){if(pkg.dependencies) delete pkg.dependencies[name]; if(pkg.devDependencies) delete pkg.devDependencies[name];}for(const name of required){if(!pkg.dependencies[name]){const v=(root.dependencies&&root.dependencies[name])||(root.devDependencies&&root.devDependencies[name]);if(v) pkg.dependencies[name]=v;}}fs.writeFileSync(p, JSON.stringify(pkg, null, 2)+"\n");'
 
+      - name: Set root build script for website deployment
+        run: |
+          node -e 'const fs=require("fs");const p="package.json";const pkg=JSON.parse(fs.readFileSync(p,"utf8"));pkg.scripts=pkg.scripts||{};pkg.scripts.build="pnpm --dir apps/website build";fs.writeFileSync(p, JSON.stringify(pkg, null, 2)+"\n");'
+
       - name: Deploy website to Vercel
         run: |
           set -euo pipefail
@@ -201,6 +205,10 @@ jobs:
       - name: Prepare admin package manifest for Vercel build
         run: |
           node -e 'const fs=require("fs");const root=JSON.parse(fs.readFileSync("package.json","utf8"));const p="apps/admin/package.json";const pkg=JSON.parse(fs.readFileSync(p,"utf8"));const internal=["@elzatona/common-ui","@elzatona/contexts","@elzatona/database","@elzatona/types","@elzatona/utilities"];const required=["@sentry/nextjs"];pkg.dependencies=pkg.dependencies||{};for(const name of internal){if(pkg.dependencies) delete pkg.dependencies[name]; if(pkg.devDependencies) delete pkg.devDependencies[name];}for(const name of required){if(!pkg.dependencies[name]){const v=(root.dependencies&&root.dependencies[name])||(root.devDependencies&&root.devDependencies[name]);if(v) pkg.dependencies[name]=v;}}fs.writeFileSync(p, JSON.stringify(pkg, null, 2)+"\n");'
+
+      - name: Set root build script for admin deployment
+        run: |
+          node -e 'const fs=require("fs");const p="package.json";const pkg=JSON.parse(fs.readFileSync(p,"utf8"));pkg.scripts=pkg.scripts||{};pkg.scripts.build="pnpm --dir apps/admin build";fs.writeFileSync(p, JSON.stringify(pkg, null, 2)+"\n");'
 
       - name: Deploy admin to Vercel
         run: |


### PR DESCRIPTION
## Summary\n- override the root build script during deploy to call the app's Next build directly\n- keep monorepo root files available in Vercel build context\n- preserve existing failure detection and retry logic\n\n## Why\nRecent main deploy failed because Vercel still executed  / , which hit pnpm lockfile and  issues inside the remote build. This patch removes Nx from the remote build path while keeping the monorepo checkout intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build and deployment pipeline configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->