### PR TITLE
fix(admin): proxy admin routes through website rewrites

### DIFF
--- a/apps/website/next.config.ts
+++ b/apps/website/next.config.ts
@@ -4,6 +4,16 @@ import { config } from "dotenv";
 import { resolve } from "node:path";
 import { existsSync } from "node:fs";
 
+function getAdminRewriteTarget() {
+  const adminUrl = process.env.ADMIN_URL?.replace(/\/+$/, "");
+
+  if (!adminUrl || adminUrl.includes("elzatona-web.com")) {
+    return null;
+  }
+
+  return adminUrl;
+}
+
 // CRITICAL: Load environment-specific files BEFORE Next.js loads .env.local
 // This ensures NEXT_PUBLIC_ variables are set correctly
 // Next.js loads .env.local automatically, so we need to override it early
@@ -95,7 +105,30 @@ const nextConfig: NextConfig = {
 
   // Rewrites are now primarily handled by middleware to prevent loop recursion
   async rewrites() {
-    return [];
+    const adminUrl = getAdminRewriteTarget();
+
+    if (!adminUrl) {
+      return [];
+    }
+
+    return [
+      {
+        source: "/admin",
+        destination: `${adminUrl}/admin`,
+      },
+      {
+        source: "/admin/:path*",
+        destination: `${adminUrl}/admin/:path*`,
+      },
+      {
+        source: "/api/admin/:path*",
+        destination: `${adminUrl}/api/admin/:path*`,
+      },
+      {
+        source: "/admin/_next/:path*",
+        destination: `${adminUrl}/_next/:path*`,
+      },
+    ];
   },
 
   // Disable automatic error page generation


### PR DESCRIPTION
## Summary
- add explicit Next rewrites for /admin, /admin/*, /admin/_next/*, and /api/admin/*
- keep middleware as-is, but stop relying on it alone for admin routing
- preserve the existing ADMIN_URL loop guard

## Why
Direct requests to https://elzatona-web.com/admin and https://elzatona-web.com/admin/content-management were still returning 404 even though the admin page exists in apps/admin/src/app/admin/content-management/page.tsx. The website now proxies those paths at the Next config layer as a more reliable fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated request routing configuration to conditionally forward admin-related requests to an external service when properly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->