### PR TITLE
fix(admin): add production fallback proxy target

### DIFF
--- a/apps/website/middleware.ts
+++ b/apps/website/middleware.ts
@@ -19,9 +19,8 @@ function getAdminTargetUrl(request: NextRequest): string | null {
     return "http://localhost:3001";
   }
 
-  // In production, we MUST have ADMIN_URL set.
-  // Returning null here will trigger an error response instead of a private DNS leak.
-  return null;
+  // Production fallback: use canonical admin server when ADMIN_URL is missing or invalid.
+  return "https://elzatona-admin.vercel.app";
 }
 
 export function middleware(request: NextRequest): NextResponse | Response {

--- a/apps/website/next.config.ts
+++ b/apps/website/next.config.ts
@@ -7,11 +7,13 @@ import { existsSync } from "node:fs";
 function getAdminRewriteTarget() {
   const adminUrl = process.env.ADMIN_URL?.replace(/\/+$/, "");
 
-  if (!adminUrl || adminUrl.includes("elzatona-web.com")) {
-    return null;
+  if (adminUrl && !adminUrl.includes("elzatona-web.com")) {
+    return adminUrl;
   }
 
-  return adminUrl;
+  return process.env.NODE_ENV === "production"
+    ? "https://elzatona-admin.vercel.app"
+    : null;
 }
 
 // CRITICAL: Load environment-specific files BEFORE Next.js loads .env.local


### PR DESCRIPTION
## Summary\n- add production fallback admin target in website middleware\n- add production fallback admin rewrite target in website next config\n- keep localhost behavior unchanged for local development\n\n## Why\n and  returned 404 on the main domain while the admin app itself was reachable on . This adds a safe fallback when  is missing/invalid in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved admin request routing with enhanced fallback configuration to ensure admin features work reliably even when custom settings are missing or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->