### PR TITLE
fix(website): redirect /admin routes to admin domain

### DIFF
--- a/apps/website/src/app/admin/[[...path]]/page.tsx
+++ b/apps/website/src/app/admin/[[...path]]/page.tsx
@@ -1,0 +1,59 @@
+import { redirect } from "next/navigation";
+
+type QueryValue = string | string[] | undefined;
+type QueryParams = Record<string, QueryValue>;
+
+type Props = {
+  params: Promise<{ path?: string[] }>;
+  searchParams?: Promise<QueryParams>;
+};
+
+function getAdminBaseUrl(): string {
+  const configured = process.env.ADMIN_URL?.trim().replace(/\/+$/, "");
+
+  if (configured && !configured.includes("elzatona-web.com")) {
+    return configured;
+  }
+
+  return "https://elzatona-admin.vercel.app";
+}
+
+function buildRedirectUrl(
+  adminPath: string[] | undefined,
+  searchParams: QueryParams,
+): string {
+  const baseUrl = getAdminBaseUrl();
+  const pathname =
+    adminPath && adminPath.length > 0 ? `/${adminPath.join("/")}` : "";
+  const qs = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(searchParams)) {
+    if (value === undefined) {
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        qs.append(key, item);
+      }
+      continue;
+    }
+
+    qs.set(key, value);
+  }
+
+  const query = qs.toString();
+  return `${baseUrl}/admin${pathname}${query ? `?${query}` : ""}`;
+}
+
+export default async function AdminProxyFallbackPage({
+  params,
+  searchParams,
+}: Props): Promise<never> {
+  const resolvedParams = await params;
+  const resolvedSearchParams = (
+    searchParams ? await searchParams : {}
+  ) as QueryParams;
+
+  redirect(buildRedirectUrl(resolvedParams.path, resolvedSearchParams));
+}


### PR DESCRIPTION
## Summary
- add a dedicated app route at /admin/[[...path]] in website
- redirect all /admin navigations to the admin deployment URL
- preserve query parameters and support optional ADMIN_URL override

## Why
Production still returned website 404 for /admin on main domain even after middleware/rewrite fallback deploys. This route-level fallback guarantees admin routes do not 404.

## Validation
- pnpm --dir apps/website run build